### PR TITLE
Escape user and error text in Markdown replies

### DIFF
--- a/command/hi.ts
+++ b/command/hi.ts
@@ -1,8 +1,9 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { ExtendedMessage } from '../MessageRouter';
+import { escapeMarkdown } from '../utils';
 
 export default (bot: TelegramBot, msg: ExtendedMessage): void => {
     const who: string = msg.from?.first_name || msg.from?.username || 'stranger';
 
-    msg.reply(`Hello to you too, ${who}!`);
+    msg.reply(`Hello to you too, ${escapeMarkdown(who)}!`);
 };

--- a/command/rollcall.ts
+++ b/command/rollcall.ts
@@ -1,6 +1,6 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { ExtendedMessage } from '../MessageRouter';
-import { pickRandom } from '../utils';
+import { pickRandom, escapeMarkdown } from '../utils';
 import DAO from '../dao/DAO';
 
 const dao = new DAO();
@@ -23,7 +23,7 @@ const executeRollcall = (bot: TelegramBot, chat_id: number, reply_to_message_id?
 
 export default (bot: TelegramBot, msg: ExtendedMessage): void => {
     executeRollcall(bot, msg.chat.id, msg.message_id)
-        .catch((err: Error) => msg.reply(`*${err.toString()}*`));
+        .catch((err: Error) => msg.reply(`*${escapeMarkdown(err.toString())}*`));
 };
 
 export { executeRollcall };

--- a/command/wingman.ts
+++ b/command/wingman.ts
@@ -1,6 +1,6 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { ExtendedMessage } from '../MessageRouter';
-import { pickRandom } from '../utils';
+import { pickRandom, escapeMarkdown } from '../utils';
 import DAO from '../dao/DAO';
 
 const dao = new DAO();
@@ -15,5 +15,5 @@ const QUOTES: string[] = [
 export default (bot: TelegramBot, msg: ExtendedMessage): void => {
     dao.getRollcallPlayerUsernames(msg.chat?.id || 0)
         .then((players: string[]) => msg.reply(`${pickRandom(QUOTES)}\n${players.join(' ')}`))
-        .catch((err: Error) => msg.reply(`*${err.toString()}*`));
+        .catch((err: Error) => msg.reply(`*${escapeMarkdown(err.toString())}*`));
 };


### PR DESCRIPTION
## Bug

All replies are sent with `parse_mode: 'Markdown'`, but `/hi` interpolated the user's raw first name/username, and `/rollcall` and `/wingman` interpolated raw error text into their error replies. If the text contains `_`, `*`, `` ` `` or `[` (e.g. a Telegram first name like `John_Doe`), Telegram rejects the message with a 400 and the user gets no reply at all.

## Fix

Wrap the interpolated text with the existing `escapeMarkdown` helper from `utils.ts` in all three handlers.

https://claude.ai/code/session_01MWnTMMwgw9qd8WdVXbZSA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWnTMMwgw9qd8WdVXbZSA4)_