### PR TITLE
Share DAO write locks across all instances

### DIFF
--- a/dao/DAO.ts
+++ b/dao/DAO.ts
@@ -32,17 +32,14 @@ export interface RollcallPlayer {
 export type ScheduledRollcalls = Record<string, string>;
 
 class DAO {
-    private locks: Map<string, Promise<any>>;
-
-    constructor() {
-        this.locks = new Map();
-    }
+    // Static so that all DAO instances (one per module) serialize writes to the same files
+    private static locks: Map<string, Promise<any>> = new Map();
 
     async _withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-        if (!this.locks.has(key)) {
-            this.locks.set(key, Promise.resolve());
+        if (!DAO.locks.has(key)) {
+            DAO.locks.set(key, Promise.resolve());
         }
-        const lock = this.locks.get(key)!;
+        const lock = DAO.locks.get(key)!;
         const nextLock = lock.then(async () => {
             try {
                 return await fn();
@@ -52,7 +49,7 @@ class DAO {
             }
         });
         // Ensure the next lock doesn't fail just because this one did
-        this.locks.set(key, nextLock.catch(() => {}));
+        DAO.locks.set(key, nextLock.catch(() => {}));
         return nextLock;
     }
 


### PR DESCRIPTION
## Bug

`DAO._withLock` serialized read-modify-write operations through a **per-instance** lock map, but nearly every module constructs its own `new DAO()` (main.ts, SteamService, and each command handler). Two commands touching the same JSON file — e.g. `/timezone` and `/steam_user_id` on `user_settings.json`, or `/schedule` / `/cancel` / the scheduler loop on `rollcall_schedules.json` — went through *different* lock maps, so their load→modify→save sequences could interleave and silently lose one of the updates.

## Fix

Make the lock map `static` so every DAO instance shares the same per-file lock chain. Verified with a concurrency smoke test that two separate DAO instances now serialize work on the same key.

https://claude.ai/code/session_01MWnTMMwgw9qd8WdVXbZSA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWnTMMwgw9qd8WdVXbZSA4)_