### PR TITLE
Guard against mention/argument misalignment in rollcall_remove_player

### DIFF
--- a/command/admin/rollcall_remove_player.ts
+++ b/command/admin/rollcall_remove_player.ts
@@ -12,6 +12,9 @@ export default (bot: TelegramBot, msg: ExtendedMessage): void => {
     if (args.length === 0) {
         msg.reply('Who would you like to remove?');
         return;
+    } else if (args.length !== mentions.length) {
+        msg.reply(`${args.length} arguments contained ${mentions.length} user mentions.`);
+        return;
     } else if (args.length !== new Set(args).size) {
         msg.reply('Seems you\'ve got some duplicate entries in there, bud!');
         return;


### PR DESCRIPTION
## Bug

`/rollcall_remove_player` zips `args[i]` with `mentions[i]`, but unlike `/rollcall_add_player` it never verified that every argument is actually a mention. If a plain-text name was mixed with a `text_mention` (e.g. `/rollcall_remove_player Bob <Alice as text mention>`), the indices shifted: `Bob` got paired with Alice's mention entity and turned into `[Bob](tg://user?id=<Alice's id>)`, so the wrong stored entry could be matched and removed.

## Fix

Add the same `args.length !== mentions.length` guard (and reply message) that `rollcall_add_player.ts` already uses, so the zip is only performed when every argument has a corresponding mention entity.

https://claude.ai/code/session_01MWnTMMwgw9qd8WdVXbZSA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWnTMMwgw9qd8WdVXbZSA4)_