### PR TITLE
Fail closed in /steam_guard when no admin is configured

### DIFF
--- a/command/steam_guard.ts
+++ b/command/steam_guard.ts
@@ -4,7 +4,11 @@ import SteamService from '../SteamService';
 
 export default (bot: TelegramBot, msg: ExtendedMessage): void => {
     const adminId: string | undefined = process.env.STEAM_ADMIN_TELEGRAM_USER_ID;
-    if (adminId && String(msg.from?.id) !== String(adminId)) {
+    if (!adminId) {
+        console.warn('STEAM_ADMIN_TELEGRAM_USER_ID is not set; refusing /steam_guard from user ' + msg.from?.id);
+        return;
+    }
+    if (String(msg.from?.id) !== String(adminId)) {
         console.warn(`Unauthorized attempt to use /steam_guard by user ${msg.from?.id}`);
         return;
     }

--- a/command/steam_guard.ts
+++ b/command/steam_guard.ts
@@ -7,8 +7,7 @@ export default (bot: TelegramBot, msg: ExtendedMessage): void => {
     if (!adminId) {
         console.warn('STEAM_ADMIN_TELEGRAM_USER_ID is not set; refusing /steam_guard from user ' + msg.from?.id);
         return;
-    }
-    if (String(msg.from?.id) !== String(adminId)) {
+    } else if (String(msg.from?.id) !== String(adminId)) {
         console.warn(`Unauthorized attempt to use /steam_guard by user ${msg.from?.id}`);
         return;
     }


### PR DESCRIPTION
## Bug

The `/steam_guard` auth check was `if (adminId && ...)` — it only rejected non-admins when `STEAM_ADMIN_TELEGRAM_USER_ID` was actually set. On deployments without that env var, **anyone** in any chat with the bot could submit Steam Guard codes to the bot's Steam login flow.

## Fix

Fail closed: when no admin user ID is configured, refuse the command and log a server-side warning instead of accepting the code. Behaviour when the admin ID *is* set is unchanged.

https://claude.ai/code/session_01MWnTMMwgw9qd8WdVXbZSA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWnTMMwgw9qd8WdVXbZSA4)_