### PR TITLE
Suppress "not a friend" warnings until the friends list has loaded

### DIFF
--- a/SteamService.ts
+++ b/SteamService.ts
@@ -39,6 +39,7 @@ class SteamService {
     private steamToTelegram: Record<string, number>;
     private appIdCS2: number;
     private steamGuardCallback: ((code: string) => void) | null;
+    private friendsListLoaded: boolean = false;
     private adminUserId: string | undefined;
     private updateInterval: NodeJS.Timeout | null;
     private reconnectTimer: NodeJS.Timeout | null;
@@ -118,6 +119,7 @@ class SteamService {
 
         this.client.on('friendsList', () => {
             console.log(`Friends list loaded. Bot has ${Object.keys(this.client.myFriends).length} friends.`);
+            this.friendsListLoaded = true;
             this.updateUserMappings();
         });
 
@@ -201,7 +203,7 @@ class SteamService {
                     newMappings[steamId] = Number(tgId);
                     steamIds.push(steamId);
 
-                    if (this.client.myFriends && this.client.myFriends[steamId] !== SteamUser.EFriendRelationship.Friend) {
+                    if (this.friendsListLoaded && this.client.myFriends && this.client.myFriends[steamId] !== SteamUser.EFriendRelationship.Friend) {
                         console.warn(`Tracked user ${tgId} (Steam ID: ${steamId}) is NOT a friend of the bot account. Updates might not work.`);
                     }
                 }


### PR DESCRIPTION
## Bug

`updateUserMappings` runs at login and on a 60-second interval. Until steam-user's `friendsList` event fires, `client.myFriends` is empty, so the relationship check `myFriends[steamId] !== Friend` was true for *every* tracked user — logging a misleading `is NOT a friend of the bot account` warning for users who are actually friends.

## Fix

Track a `friendsListLoaded` flag, set in the existing `friendsList` handler, and only perform the relationship warning once the list has actually loaded.

https://claude.ai/code/session_01MWnTMMwgw9qd8WdVXbZSA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWnTMMwgw9qd8WdVXbZSA4)_