### PR TITLE
Add GitHub commit notifications service

### DIFF
--- a/GitHubService.ts
+++ b/GitHubService.ts
@@ -125,14 +125,10 @@ class GitHubService {
     }
 
     private formatCommit(commit: GitHubCommit): string {
-        const shortSha = commit.sha.substring(0, 7);
-        const firstLine = (commit.commit.message || '').split('\n')[0];
-        const author = commit.author?.login || commit.commit.author?.name || 'unknown';
+        const message = commit.commit.message || '';
 
-        return `📦 New commit to *${escapeMarkdown(this.repo)}*\n` +
-            `\`${shortSha}\` ${escapeMarkdown(firstLine)}\n` +
-            `by ${escapeMarkdown(author)}\n` +
-            commit.html_url;
+        return `New commit: ${commit.html_url}\n` +
+            escapeMarkdown(message);
     }
 }
 

--- a/GitHubService.ts
+++ b/GitHubService.ts
@@ -1,0 +1,139 @@
+import TelegramBot from 'node-telegram-bot-api';
+import DAO from './dao/DAO';
+import { escapeMarkdown } from './utils';
+
+interface GitHubCommit {
+    sha: string;
+    html_url: string;
+    commit: {
+        message: string;
+        author?: {
+            name?: string;
+            date?: string;
+        };
+    };
+    author?: {
+        login?: string;
+    } | null;
+}
+
+const DEFAULT_REPO = 'RobinJ1995/totaleBlindheidBot';
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+class GitHubService {
+    private bot: TelegramBot;
+    private dao: DAO;
+    private repo: string;
+    private intervalMs: number;
+    private pollInterval: NodeJS.Timeout | null;
+
+    constructor(bot: TelegramBot) {
+        this.bot = bot;
+        this.dao = new DAO();
+        this.repo = process.env.GITHUB_REPO || DEFAULT_REPO;
+        const configured = Number(process.env.GITHUB_POLL_INTERVAL_MS);
+        this.intervalMs = Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_INTERVAL_MS;
+        this.pollInterval = null;
+    }
+
+    start(): void {
+        console.log(`Starting GitHubService for repo ${this.repo} (polling every ${this.intervalMs / 1000}s)`);
+
+        // Kick off an immediate poll so the baseline SHA is established promptly.
+        this.pollAndNotify().catch((err: Error) => console.error('Error in initial GitHub poll:', err));
+
+        this.pollInterval = setInterval(() => {
+            this.pollAndNotify().catch((err: Error) => console.error('Error in GitHub poll:', err));
+        }, this.intervalMs);
+    }
+
+    stop(): void {
+        if (this.pollInterval) {
+            clearInterval(this.pollInterval);
+            this.pollInterval = null;
+        }
+    }
+
+    private async fetchCommits(): Promise<GitHubCommit[] | null> {
+        const headers: Record<string, string> = {
+            'User-Agent': 'totaleBlindheidBot',
+            'Accept': 'application/vnd.github+json'
+        };
+        if (process.env.GITHUB_TOKEN) {
+            headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+        }
+
+        const url = `https://api.github.com/repos/${this.repo}/commits?per_page=20`;
+        const res = await fetch(url, { headers });
+        if (!res.ok) {
+            console.error(`GitHub API request failed: ${res.status} ${res.statusText}`);
+            return null;
+        }
+
+        const body = await res.json();
+        return Array.isArray(body) ? body as GitHubCommit[] : null;
+    }
+
+    private async pollAndNotify(): Promise<void> {
+        const commits = await this.fetchCommits();
+        if (!commits || commits.length === 0) {
+            return;
+        }
+
+        // GitHub returns newest first.
+        const newestSha = commits[0].sha;
+        const lastSha = await this.dao.getGithubLastSha();
+
+        // First ever run: record the baseline without announcing historical commits.
+        if (!lastSha) {
+            await this.dao.setGithubLastSha(newestSha);
+            console.log(`GitHub baseline established at ${newestSha}`);
+            return;
+        }
+
+        if (newestSha === lastSha) {
+            return; // Nothing new.
+        }
+
+        // Collect commits newer than lastSha (newest-first slice up to the known SHA).
+        const lastIndex = commits.findIndex(c => c.sha === lastSha);
+        // If lastSha isn't on this page (>20 new commits, or history rewritten),
+        // only announce the newest commit to avoid flooding chats.
+        const newCommits = lastIndex === -1 ? [commits[0]] : commits.slice(0, lastIndex);
+
+        // Announce oldest-first so chats read them in chronological order.
+        const ordered = [...newCommits].reverse();
+
+        const chats = await this.dao.getGithubNotifyChats();
+        if (chats.length > 0) {
+            for (const commit of ordered) {
+                const text = this.formatCommit(commit);
+                for (const chatId of chats) {
+                    try {
+                        await this.bot.sendMessage(chatId, text, {
+                            parse_mode: 'Markdown',
+                            disable_web_page_preview: true
+                        });
+                    } catch (err) {
+                        console.error(`Failed to send GitHub notification to chat ${chatId}:`, err);
+                    }
+                }
+            }
+        }
+
+        await this.dao.setGithubLastSha(newestSha);
+    }
+
+    private formatCommit(commit: GitHubCommit): string {
+        const shortSha = commit.sha.substring(0, 7);
+        const firstLine = (commit.commit.message || '').split('\n')[0];
+        const author = commit.author?.login || commit.commit.author?.name || 'unknown';
+
+        return `📦 New commit to *${escapeMarkdown(this.repo)}*\n` +
+            `\`${shortSha}\` ${escapeMarkdown(firstLine)}\n` +
+            `by ${escapeMarkdown(author)}\n` +
+            commit.html_url;
+    }
+}
+
+export default GitHubService;

--- a/command/github_notify.ts
+++ b/command/github_notify.ts
@@ -1,0 +1,21 @@
+import TelegramBot from 'node-telegram-bot-api';
+import { ExtendedMessage } from '../MessageRouter';
+import DAO from '../dao/DAO';
+import { formatError } from '../utils';
+
+const dao = new DAO();
+
+export default (bot: TelegramBot, msg: ExtendedMessage): void => {
+    const arg: string | undefined = msg.command?.argument?.toLowerCase();
+    if (arg !== 'on' && arg !== 'off') {
+        msg.reply('Please specify "on" or "off" to enable or disable GitHub notifications for this chat.');
+        return;
+    }
+
+    const enabled: boolean = arg === 'on';
+    dao.setGithubNotify(msg.chat.id, enabled)
+        .then(() => {
+            msg.reply(`GitHub notifications for this chat have been turned ${arg}.`);
+        })
+        .catch((err: Error) => msg.reply(formatError(err)));
+};

--- a/dao/DAO.ts
+++ b/dao/DAO.ts
@@ -5,6 +5,8 @@ import { loadJSON, saveJSON } from './S3Client';
 const FILE_ROLLCALL_PLAYERS = 'rollcall_players.json';
 const FILE_ROLLCALL_SCHEDULES = 'rollcall_schedules.json';
 const FILE_USER_SETTINGS = 'user_settings.json';
+const FILE_GITHUB_NOTIFY_CHATS = 'github_notify_chats.json';
+const FILE_GITHUB_STATE = 'github_state.json';
 
 export interface UserSettings {
     steam_id?: string;
@@ -30,6 +32,10 @@ export interface RollcallPlayer {
 }
 
 export type ScheduledRollcalls = Record<string, string>;
+
+export interface GithubState {
+    last_sha?: string;
+}
 
 class DAO {
     private locks: Map<string, Promise<any>>;
@@ -131,6 +137,42 @@ class DAO {
                     };
                     return saveJSON(key, updated);
                 });
+        });
+    }
+
+    getGithubNotifyChats(): Promise<number[]> {
+        return loadJSON<(string | number)[]>(FILE_GITHUB_NOTIFY_CHATS)
+            .then((chats: (string | number)[]) => Array.isArray(chats) ? chats.map(id => Number(id)) : []);
+    }
+
+    setGithubNotify(chat_id: number, enabled: boolean): Promise<void> {
+        return this._withLock(FILE_GITHUB_NOTIFY_CHATS, () => {
+            return loadJSON<(string | number)[]>(FILE_GITHUB_NOTIFY_CHATS)
+                .then((stored: (string | number)[]) => {
+                    const chats: number[] = Array.isArray(stored) ? stored.map(id => Number(id)) : [];
+                    const has: boolean = chats.includes(Number(chat_id));
+                    if (enabled && !has) {
+                        chats.push(Number(chat_id));
+                    } else if (!enabled && has) {
+                        return saveJSON(FILE_GITHUB_NOTIFY_CHATS, chats.filter(id => id !== Number(chat_id)));
+                    } else if (!enabled) {
+                        return; // not present, nothing to remove
+                    } else {
+                        return; // already present, nothing to add
+                    }
+                    return saveJSON(FILE_GITHUB_NOTIFY_CHATS, chats);
+                });
+        });
+    }
+
+    getGithubLastSha(): Promise<string | undefined> {
+        return loadJSON<GithubState>(FILE_GITHUB_STATE)
+            .then((state: GithubState) => state.last_sha);
+    }
+
+    setGithubLastSha(sha: string): Promise<void> {
+        return this._withLock(FILE_GITHUB_STATE, () => {
+            return saveJSON(FILE_GITHUB_STATE, { last_sha: sha });
         });
     }
 

--- a/main.ts
+++ b/main.ts
@@ -4,6 +4,7 @@ consoleStamp(console);
 import TelegramBot from 'node-telegram-bot-api';
 import DAO from './dao/DAO';
 import SteamService from './SteamService';
+import GitHubService from './GitHubService';
 import { executeRollcall } from './command/rollcall';
 import MessageRouter, { ExtendedMessage } from './MessageRouter';
 import { escapeMarkdown } from './utils';
@@ -18,6 +19,7 @@ import wingmanHandler from './command/wingman';
 import steamUserIdHandler from './command/steam_user_id';
 import steamUpdatesHandler from './command/steam_updates';
 import steamGuardHandler from './command/steam_guard';
+import githubNotifyHandler from './command/github_notify';
 import rollcallAddPlayerHandler from './command/admin/rollcall_add_player';
 import rollcallRemovePlayerHandler from './command/admin/rollcall_remove_player';
 import rollcallGetPlayersHandler from './command/admin/rollcall_get_players';
@@ -61,6 +63,10 @@ if (steamEnabled) {
     steamService.start();
 }
 
+// GitHub Service (public repo, no auth required)
+const githubService: GitHubService = new GitHubService(bot);
+githubService.start();
+
 const router: MessageRouter = new MessageRouter(bot);
 
 router.route('hi', hiHandler, {
@@ -80,6 +86,9 @@ router.route('timezone', timezoneHandler, {
 });
 router.route('wingman', wingmanHandler, {
     helpText: 'Looking for a wingman?'
+});
+router.route('github_notify', githubNotifyHandler, {
+    helpText: 'Enable or disable GitHub commit notifications for this chat (on/off).'
 });
 
 if (steamEnabled) {


### PR DESCRIPTION
## Summary
This PR adds a GitHub commit monitoring service that polls a repository for new commits and sends notifications to subscribed Telegram chats. Users can enable or disable notifications per chat using the `/github_notify` command.

## Key Changes
- **New GitHubService class** (`GitHubService.ts`): Implements polling of GitHub repository commits via the GitHub API, with configurable polling interval (default 5 minutes). Tracks the latest commit SHA to identify new commits and sends formatted notifications to subscribed chats. Handles edge cases like repository history rewrites and avoids flooding chats with historical commits on first run.

- **DAO enhancements** (`dao/DAO.ts`): Added methods to manage GitHub notification subscriptions (`getGithubNotifyChats`, `setGithubNotify`) and track polling state (`getGithubLastSha`, `setGithubLastSha`). Data is persisted to S3 via JSON files.

- **New command handler** (`command/github_notify.ts`): Implements `/github_notify on|off` command to allow users to enable or disable GitHub notifications for their chat.

- **Main service integration** (`main.ts`): Instantiates and starts the GitHubService on bot startup. Registers the new command handler with the message router.

## Notable Implementation Details
- Supports optional GitHub token via `GITHUB_TOKEN` environment variable for higher API rate limits
- Configurable repository and polling interval via environment variables (`GITHUB_REPO`, `GITHUB_POLL_INTERVAL_MS`)
- Commits are announced in chronological order (oldest-first) for better readability
- Gracefully handles API failures and missing commits without crashing
- Uses Markdown formatting with proper escaping for commit messages and author names
- Establishes a baseline on first run to avoid announcing historical commits

https://claude.ai/code/session_01Xu7eCgng5zUjfSM6Fmyrbf