### PR TITLE
Restrict Docker image builds to master branch only

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,6 +1,9 @@
 name: Build Docker images
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Modified the Docker image build workflow to only trigger on pushes to the master branch, rather than triggering on all push events.

## Key Changes
- Updated the `on` trigger configuration in the build-docker-image workflow from a simple `[push]` to a more specific trigger that filters by branch
- Added explicit branch specification to limit builds to the `master` branch only

## Implementation Details
This change prevents the Docker image build workflow from running on every push to any branch, reducing unnecessary CI/CD overhead. The workflow will now only execute when code is pushed to the master branch, which is typically the production or main release branch.

https://claude.ai/code/session_011yj7T8SMYNgiVKVgiVxgAw