### PR TITLE
Show commit message in an expandable blockquote

### DIFF
--- a/GitHubService.ts
+++ b/GitHubService.ts
@@ -128,7 +128,7 @@ class GitHubService {
         const message = commit.commit.message || '';
 
         return `New commit: ${escapeHtml(commit.html_url)}\n` +
-            `<blockquote>${escapeHtml(message)}</blockquote>`;
+            `<blockquote expandable>${escapeHtml(message)}</blockquote>`;
     }
 }
 

--- a/GitHubService.ts
+++ b/GitHubService.ts
@@ -1,6 +1,6 @@
 import TelegramBot from 'node-telegram-bot-api';
 import DAO from './dao/DAO';
-import { escapeMarkdown } from './utils';
+import { escapeHtml } from './utils';
 
 interface GitHubCommit {
     sha: string;
@@ -111,7 +111,7 @@ class GitHubService {
                 for (const chatId of chats) {
                     try {
                         await this.bot.sendMessage(chatId, text, {
-                            parse_mode: 'Markdown',
+                            parse_mode: 'HTML',
                             disable_web_page_preview: true
                         });
                     } catch (err) {
@@ -127,8 +127,8 @@ class GitHubService {
     private formatCommit(commit: GitHubCommit): string {
         const message = commit.commit.message || '';
 
-        return `New commit: ${commit.html_url}\n` +
-            escapeMarkdown(message);
+        return `New commit: ${escapeHtml(commit.html_url)}\n` +
+            `<blockquote>${escapeHtml(message)}</blockquote>`;
     }
 }
 

--- a/utils.ts
+++ b/utils.ts
@@ -65,6 +65,11 @@ const escapeMarkdown = (text: string): string => {
     return text.replace(/([`_*\\(\[])/g, '\\$1');
 }
 
+const escapeHtml = (text: string): string => {
+    // Escape the characters that are significant in Telegram's HTML parse mode
+    return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 const formatError = (err: Error): string => {
     if (err.stack) {
         return escapeMarkdown(err.stack);
@@ -81,6 +86,7 @@ export {
     pickRandom,
     promiseLog,
     escapeMarkdown,
+    escapeHtml,
     formatError,
     NullValueError,
     EmptyValueError,


### PR DESCRIPTION
## Summary
Follow-up to #16. Improves the formatting of GitHub commit notifications so the commit message renders in an expandable Telegram quote box.

## Changes
- Switch GitHub notifications from legacy `Markdown` to `HTML` parse mode (legacy Markdown doesn't support blockquotes).
- Wrap the commit message in `<blockquote expandable>` so long messages stay collapsed by default with a "show more" toggle.
- Add an `escapeHtml` helper in `utils.ts` (mirroring the existing `escapeMarkdown`) to safely embed the message and URL.

## Resulting format
```
New commit: https://github.com/.../commit/abc123
<blockquote expandable>full commit message…</blockquote>
```

https://claude.ai/code/session_01Xu7eCgng5zUjfSM6Fmyrbf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xu7eCgng5zUjfSM6Fmyrbf)_