### PR TITLE
Add multi-platform Docker image builds with QEMU support

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -10,14 +10,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Publish to Github Docker registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          name: robinj1995/totaleblindheidbot/totale-blindheid-bot
           registry: ghcr.io
           username: RobinJ1995
           password: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          snapshot: true
+
+      - name: Build and push multi-platform image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/robinj1995/totaleblindheidbot/totale-blindheid-bot:latest
+            ghcr.io/robinj1995/totaleblindheidbot/totale-blindheid-bot:${{ github.sha }}
+
       - name: Trigger deployment
         if: ${{ success() }}
         run: |


### PR DESCRIPTION
## Summary
Refactored the Docker image build workflow to support multi-platform builds (amd64 and arm64) using Docker Buildx and QEMU, replacing the previous single-platform approach.

## Key Changes
- Replaced `elgohr/Publish-Docker-Github-Action` with official Docker actions (`docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action`, and `docker/build-push-action`)
- Added QEMU setup for cross-platform emulation support
- Configured Docker Buildx for multi-platform builds targeting `linux/amd64` and `linux/arm64`
- Updated image tagging to include both `latest` and commit SHA (`github.sha`) tags
- Simplified authentication by using dedicated login action instead of inline credentials

## Implementation Details
- The workflow now builds and pushes images for both AMD64 and ARM64 architectures in a single build process
- Images are tagged with both `latest` and the current commit SHA for better version tracking
- The deployment trigger remains unchanged and will execute on successful build completion

https://claude.ai/code/session_0144KHzKTBuugoZvXtAtn2LJ