### PR TITLE
Add RSVP list system for rollcall scheduling and responses

### DIFF
--- a/command/cancel.ts
+++ b/command/cancel.ts
@@ -2,6 +2,7 @@ import TelegramBot from 'node-telegram-bot-api';
 import { ExtendedMessage } from '../MessageRouter';
 import DAO, { ScheduledRollcalls, normalizeSchedule } from '../dao/DAO';
 import { formatError } from '../utils';
+import { retireRsvpList } from '../rsvp';
 
 const dao = new DAO();
 
@@ -12,7 +13,7 @@ export default (bot: TelegramBot, msg: ExtendedMessage): void => {
             if (schedules[chat_id]) {
                 const schedule = normalizeSchedule(schedules[chat_id]);
                 return dao.removeScheduledRollcall(chat_id)
-                    .then(() => schedule.rsvp_id ? dao.deleteRsvpList(schedule.rsvp_id) : undefined)
+                    .then(() => schedule.rsvp_id ? retireRsvpList(bot, dao, schedule.rsvp_id) : undefined)
                     .then(() => {
                         msg.reply('Scheduled rollcall cancelled.');
                     });

--- a/command/cancel.ts
+++ b/command/cancel.ts
@@ -1,18 +1,18 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { ExtendedMessage } from '../MessageRouter';
-import DAO from '../dao/DAO';
+import DAO, { ScheduledRollcalls, normalizeSchedule } from '../dao/DAO';
 import { formatError } from '../utils';
 
 const dao = new DAO();
-
-import { ScheduledRollcalls } from '../dao/DAO';
 
 export default (bot: TelegramBot, msg: ExtendedMessage): void => {
     const chat_id: number = msg.chat.id;
     dao.getScheduledRollcalls()
         .then((schedules: ScheduledRollcalls) => {
             if (schedules[chat_id]) {
+                const schedule = normalizeSchedule(schedules[chat_id]);
                 return dao.removeScheduledRollcall(chat_id)
+                    .then(() => schedule.rsvp_id ? dao.deleteRsvpList(schedule.rsvp_id) : undefined)
                     .then(() => {
                         msg.reply('Scheduled rollcall cancelled.');
                     });

--- a/command/rollcall.ts
+++ b/command/rollcall.ts
@@ -1,7 +1,8 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { ExtendedMessage } from '../MessageRouter';
 import { pickRandom, escapeMarkdown } from '../utils';
-import DAO from '../dao/DAO';
+import DAO, { RsvpEntry } from '../dao/DAO';
+import { keyboard, resolve, renderMessage } from '../rsvp';
 
 const dao = new DAO();
 
@@ -13,17 +14,58 @@ const QUOTES: string[] = [
     "RUSH B DON'T STOP"
 ];
 
-const executeRollcall = (bot: TelegramBot, chat_id: number, reply_to_message_id?: number): Promise<TelegramBot.Message> => {
-    return dao.getRollcallPlayerUsernames(chat_id)
-        .then((players: string[]) => bot.sendMessage(chat_id, `${pickRandom(QUOTES)}\n${players.join(' ')}`, {
-            reply_to_message_id,
-            parse_mode: 'Markdown'
-        }));
+interface ExecuteRollcallOptions {
+    reply_to_message_id?: number;
+    initiator_id?: number;
+    initiator_name?: string;
+    initiator_username?: string;
+    // When set, the rollcall attaches to (shares) this existing RSVP list instead of
+    // creating a fresh one. Used when a schedule triggers the rollcall.
+    rsvp_id?: string;
+}
+
+const executeRollcall = (bot: TelegramBot, chat_id: number, opts: ExecuteRollcallOptions = {}): Promise<TelegramBot.Message> => {
+    return Promise.all([
+        dao.getRollcallPlayerUsernames(chat_id),
+        opts.rsvp_id ? dao.getRsvpList(opts.rsvp_id) : Promise.resolve(undefined)
+    ]).then(([rotation, existing]) => {
+        // Inherit the shared list's entries when triggered by a schedule; otherwise seed
+        // a fresh list with the initiator marked as joining.
+        const entries: Record<string, RsvpEntry> = existing ? existing.entries : {};
+        if (!existing && opts.initiator_id) {
+            entries[opts.initiator_id] = {
+                user_id: opts.initiator_id,
+                name: opts.initiator_name || 'someone',
+                username: opts.initiator_username,
+                rsvp: 'yes'
+            };
+        }
+
+        const { groups, mentions } = resolve(rotation, entries);
+        // The ping line is baked in at send time: anyone who said "no" is dropped here.
+        const baseText: string = `${pickRandom(QUOTES)}\n${mentions.join(' ')}`;
+
+        return bot.sendMessage(chat_id, renderMessage(baseText, groups), {
+            reply_to_message_id: opts.reply_to_message_id,
+            parse_mode: 'Markdown',
+            reply_markup: keyboard('rollcall')
+        }).then((sent: TelegramBot.Message) => {
+            const ref = { message_id: sent.message_id, base_text: baseText, keyboard: 'rollcall' as const };
+            const attach: Promise<unknown> = (existing && opts.rsvp_id)
+                ? dao.addRsvpMessage(opts.rsvp_id, ref)
+                : dao.createRsvpList({ chat_id, entries, messages: [ref] });
+            return attach.then(() => sent);
+        });
+    });
 };
 
 export default (bot: TelegramBot, msg: ExtendedMessage): void => {
-    executeRollcall(bot, msg.chat.id, msg.message_id)
-        .catch((err: Error) => msg.reply(`*${escapeMarkdown(err.toString())}*`));
+    executeRollcall(bot, msg.chat.id, {
+        reply_to_message_id: msg.message_id,
+        initiator_id: msg.from?.id,
+        initiator_name: msg.from?.first_name || msg.from?.username,
+        initiator_username: msg.from?.username
+    }).catch((err: Error) => msg.reply(`*${escapeMarkdown(err.toString())}*`));
 };
 
 export { executeRollcall };

--- a/command/rollcall.ts
+++ b/command/rollcall.ts
@@ -2,7 +2,7 @@ import TelegramBot from 'node-telegram-bot-api';
 import { ExtendedMessage } from '../MessageRouter';
 import { pickRandom, escapeMarkdown } from '../utils';
 import DAO, { RsvpEntry } from '../dao/DAO';
-import { keyboard, resolve, renderMessage } from '../rsvp';
+import { keyboard, resolve, renderMessage, entryFromUser } from '../rsvp';
 
 const dao = new DAO();
 
@@ -16,9 +16,8 @@ const QUOTES: string[] = [
 
 interface ExecuteRollcallOptions {
     reply_to_message_id?: number;
-    initiator_id?: number;
-    initiator_name?: string;
-    initiator_username?: string;
+    // The user who triggered the rollcall; seeded into the "yes" list for a fresh list.
+    initiator?: TelegramBot.User;
     // When set, the rollcall attaches to (shares) this existing RSVP list instead of
     // creating a fresh one. Used when a schedule triggers the rollcall.
     rsvp_id?: string;
@@ -32,13 +31,8 @@ const executeRollcall = (bot: TelegramBot, chat_id: number, opts: ExecuteRollcal
         // Inherit the shared list's entries when triggered by a schedule; otherwise seed
         // a fresh list with the initiator marked as joining.
         const entries: Record<string, RsvpEntry> = existing ? existing.entries : {};
-        if (!existing && opts.initiator_id) {
-            entries[opts.initiator_id] = {
-                user_id: opts.initiator_id,
-                name: opts.initiator_name || 'someone',
-                username: opts.initiator_username,
-                rsvp: 'yes'
-            };
+        if (!existing && opts.initiator) {
+            entries[opts.initiator.id] = entryFromUser(opts.initiator, 'yes');
         }
 
         const { groups, mentions } = resolve(rotation, entries);
@@ -62,9 +56,7 @@ const executeRollcall = (bot: TelegramBot, chat_id: number, opts: ExecuteRollcal
 export default (bot: TelegramBot, msg: ExtendedMessage): void => {
     executeRollcall(bot, msg.chat.id, {
         reply_to_message_id: msg.message_id,
-        initiator_id: msg.from?.id,
-        initiator_name: msg.from?.first_name || msg.from?.username,
-        initiator_username: msg.from?.username
+        initiator: msg.from
     }).catch((err: Error) => msg.reply(`*${escapeMarkdown(err.toString())}*`));
 };
 

--- a/command/schedule.ts
+++ b/command/schedule.ts
@@ -1,8 +1,9 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { ExtendedMessage } from '../MessageRouter';
 import { parseTime } from '../timeUtils';
-import DAO from '../dao/DAO';
+import DAO, { RsvpEntry } from '../dao/DAO';
 import { formatError, escapeMarkdown } from '../utils';
+import { keyboard, resolve, renderMessage } from '../rsvp';
 
 const dao = new DAO();
 
@@ -38,7 +39,8 @@ export default (bot: TelegramBot, msg: ExtendedMessage): void => {
 
             const chat_id: number = msg.chat.id;
             return dao.setScheduledRollcall(chat_id, scheduledTime)
-                .then(() => {
+                .then(() => dao.getRollcallPlayerUsernames(chat_id))
+                .then((rotation: string[]) => {
                     const timeString: string = scheduledTime.toLocaleString('en-GB', {
                         timeZone: timezone,
                         year: 'numeric',
@@ -49,7 +51,36 @@ export default (bot: TelegramBot, msg: ExtendedMessage): void => {
                         second: 'numeric',
                         timeZoneName: 'short'
                     });
-                    msg.reply(`Rollcall scheduled for ${escapeMarkdown(timeString)}`);
+
+                    // Seed the initiator into the "yes" list.
+                    const entries: Record<string, RsvpEntry> = {};
+                    if (user_id) {
+                        entries[user_id] = {
+                            user_id,
+                            name: msg.from?.first_name || msg.from?.username || 'someone',
+                            username: msg.from?.username,
+                            rsvp: 'yes'
+                        };
+                    }
+
+                    const baseText: string = `Rollcall scheduled for ${escapeMarkdown(timeString)}`;
+                    const { groups } = resolve(rotation, entries);
+
+                    return bot.sendMessage(chat_id, renderMessage(baseText, groups), {
+                        reply_to_message_id: msg.message_id,
+                        parse_mode: 'Markdown',
+                        reply_markup: keyboard('schedule')
+                    }).then((sent: TelegramBot.Message) => {
+                        return dao.createRsvpList({
+                            chat_id,
+                            entries,
+                            messages: [{ message_id: sent.message_id, base_text: baseText, keyboard: 'schedule' }]
+                        }).then((rsvp_id: string) =>
+                            // Store the rsvp_id + initiator on the schedule so the timer can
+                            // find and share the same list when the rollcall fires.
+                            dao.setScheduledRollcall(chat_id, scheduledTime, rsvp_id, user_id)
+                        );
+                    });
                 });
         })
         .catch((err: Error) => msg.reply(formatError(err)));

--- a/command/schedule.ts
+++ b/command/schedule.ts
@@ -1,9 +1,9 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { ExtendedMessage } from '../MessageRouter';
 import { parseTime } from '../timeUtils';
-import DAO, { RsvpEntry } from '../dao/DAO';
+import DAO, { RsvpEntry, normalizeSchedule } from '../dao/DAO';
 import { formatError, escapeMarkdown } from '../utils';
-import { keyboard, resolve, renderMessage } from '../rsvp';
+import { keyboard, resolve, renderMessage, entryFromUser, retireRsvpList } from '../rsvp';
 
 const dao = new DAO();
 
@@ -38,7 +38,15 @@ export default (bot: TelegramBot, msg: ExtendedMessage): void => {
             }
 
             const chat_id: number = msg.chat.id;
-            return dao.setScheduledRollcall(chat_id, scheduledTime)
+            // Rescheduling replaces any existing schedule for this chat: retire the previous
+            // RSVP list first so its stale confirmation buttons can't record responses against
+            // a schedule that will never fire.
+            return dao.getScheduledRollcalls()
+                .then(schedules => {
+                    const previous = schedules[chat_id] ? normalizeSchedule(schedules[chat_id]) : undefined;
+                    return previous?.rsvp_id ? retireRsvpList(bot, dao, previous.rsvp_id) : undefined;
+                })
+                .then(() => dao.setScheduledRollcall(chat_id, scheduledTime))
                 .then(() => dao.getRollcallPlayerUsernames(chat_id))
                 .then((rotation: string[]) => {
                     const timeString: string = scheduledTime.toLocaleString('en-GB', {
@@ -54,13 +62,8 @@ export default (bot: TelegramBot, msg: ExtendedMessage): void => {
 
                     // Seed the initiator into the "yes" list.
                     const entries: Record<string, RsvpEntry> = {};
-                    if (user_id) {
-                        entries[user_id] = {
-                            user_id,
-                            name: msg.from?.first_name || msg.from?.username || 'someone',
-                            username: msg.from?.username,
-                            rsvp: 'yes'
-                        };
+                    if (msg.from) {
+                        entries[msg.from.id] = entryFromUser(msg.from, 'yes');
                     }
 
                     const baseText: string = `Rollcall scheduled for ${escapeMarkdown(timeString)}`;

--- a/dao/DAO.ts
+++ b/dao/DAO.ts
@@ -4,9 +4,13 @@ import { loadJSON, saveJSON } from './S3Client';
 
 const FILE_ROLLCALL_PLAYERS = 'rollcall_players.json';
 const FILE_ROLLCALL_SCHEDULES = 'rollcall_schedules.json';
+const FILE_RSVP_LISTS = 'rsvp_lists.json';
 const FILE_USER_SETTINGS = 'user_settings.json';
 const FILE_GITHUB_NOTIFY_CHATS = 'github_notify_chats.json';
 const FILE_GITHUB_STATE = 'github_state.json';
+
+// RSVP lists older than this are pruned on write.
+const RSVP_LIST_TTL_MS = 24 * 60 * 60 * 1000;
 
 export interface UserSettings {
     steam_id?: string;
@@ -31,7 +35,40 @@ export interface RollcallPlayer {
     key?: string;
 }
 
-export type ScheduledRollcalls = Record<string, string>;
+export interface ScheduledRollcall {
+    time: string;
+    rsvp_id?: string;
+    initiator_id?: number;
+}
+
+// Stored value may be a legacy bare ISO string (time only) or the richer object above.
+export type ScheduledRollcalls = Record<string, ScheduledRollcall | string>;
+
+export const normalizeSchedule = (value: ScheduledRollcall | string): ScheduledRollcall =>
+    typeof value === 'string' ? { time: value } : value;
+
+export type Rsvp = 'yes' | 'maybe' | 'no';
+
+export interface RsvpEntry {
+    user_id: number;
+    name: string;        // non-pinging display name
+    username?: string;   // telegram @username (no @) for rotation matching
+    rsvp: Rsvp;
+}
+
+export interface RsvpMessageRef {
+    message_id: number;
+    base_text: string;                 // text above the lists (differs per message)
+    keyboard: 'schedule' | 'rollcall'; // which button labels to show on this message
+}
+
+export interface RsvpList {
+    rsvp_id: string;
+    chat_id: number;
+    entries: Record<string, RsvpEntry>; // keyed by user_id (incl. seeded initiator)
+    messages: RsvpMessageRef[];         // every message currently displaying this list
+    created_at: string;                 // for pruning
+}
 
 export interface GithubState {
     last_sha?: string;
@@ -209,11 +246,18 @@ class DAO {
         return loadJSON<ScheduledRollcalls>(FILE_ROLLCALL_SCHEDULES);
     }
 
-    setScheduledRollcall(chat_id: number, time: Date): Promise<void> {
+    setScheduledRollcall(chat_id: number, time: Date, rsvp_id?: string, initiator_id?: number): Promise<void> {
         return this._withLock(FILE_ROLLCALL_SCHEDULES, () => {
             return loadJSON<ScheduledRollcalls>(FILE_ROLLCALL_SCHEDULES)
                 .then(schedules => {
-                    schedules[chat_id] = time.toISOString();
+                    const schedule: ScheduledRollcall = { time: time.toISOString() };
+                    if (rsvp_id !== undefined) {
+                        schedule.rsvp_id = rsvp_id;
+                    }
+                    if (initiator_id !== undefined) {
+                        schedule.initiator_id = initiator_id;
+                    }
+                    schedules[chat_id] = schedule;
                     return saveJSON(FILE_ROLLCALL_SCHEDULES, schedules);
                 });
         });
@@ -225,6 +269,98 @@ class DAO {
                 .then(schedules => {
                     delete schedules[chat_id];
                     return saveJSON(FILE_ROLLCALL_SCHEDULES, schedules);
+                });
+        });
+    }
+
+    // Drop RSVP lists older than the TTL so the file doesn't grow unbounded.
+    private _pruneRsvpLists(lists: Record<string, RsvpList>): void {
+        const cutoff: number = Date.now() - RSVP_LIST_TTL_MS;
+        for (const [id, list] of Object.entries(lists)) {
+            if (new Date(list.created_at).getTime() < cutoff) {
+                delete lists[id];
+            }
+        }
+    }
+
+    createRsvpList(list: Omit<RsvpList, 'rsvp_id' | 'created_at'>): Promise<string> {
+        return this._withLock(FILE_RSVP_LISTS, () => {
+            return loadJSON<Record<string, RsvpList>>(FILE_RSVP_LISTS)
+                .then(lists => {
+                    this._pruneRsvpLists(lists);
+                    const rsvp_id: string = uuid();
+                    lists[rsvp_id] = {
+                        ...list,
+                        rsvp_id,
+                        created_at: new Date().toISOString()
+                    };
+                    return saveJSON(FILE_RSVP_LISTS, lists).then(() => rsvp_id);
+                });
+        });
+    }
+
+    getRsvpList(rsvp_id: string): Promise<RsvpList | undefined> {
+        return loadJSON<Record<string, RsvpList>>(FILE_RSVP_LISTS)
+            .then(lists => lists[rsvp_id]);
+    }
+
+    getRsvpListByMessage(chat_id: number, message_id: number): Promise<RsvpList | undefined> {
+        return loadJSON<Record<string, RsvpList>>(FILE_RSVP_LISTS)
+            .then(lists => Object.values(lists).find(list =>
+                String(list.chat_id) === String(chat_id) &&
+                list.messages.some(ref => ref.message_id === message_id)
+            ));
+    }
+
+    setRsvpEntry(rsvp_id: string, entry: RsvpEntry): Promise<RsvpList | undefined> {
+        return this._withLock(FILE_RSVP_LISTS, () => {
+            return loadJSON<Record<string, RsvpList>>(FILE_RSVP_LISTS)
+                .then(lists => {
+                    const list: RsvpList | undefined = lists[rsvp_id];
+                    if (!list) {
+                        return undefined;
+                    }
+                    list.entries[entry.user_id] = entry;
+                    return saveJSON(FILE_RSVP_LISTS, lists).then(() => list);
+                });
+        });
+    }
+
+    addRsvpMessage(rsvp_id: string, ref: RsvpMessageRef): Promise<void> {
+        return this._withLock(FILE_RSVP_LISTS, () => {
+            return loadJSON<Record<string, RsvpList>>(FILE_RSVP_LISTS)
+                .then(lists => {
+                    const list: RsvpList | undefined = lists[rsvp_id];
+                    if (!list) {
+                        return;
+                    }
+                    list.messages = list.messages.filter(m => m.message_id !== ref.message_id);
+                    list.messages.push(ref);
+                    return saveJSON(FILE_RSVP_LISTS, lists);
+                });
+        });
+    }
+
+    removeRsvpMessage(rsvp_id: string, message_id: number): Promise<void> {
+        return this._withLock(FILE_RSVP_LISTS, () => {
+            return loadJSON<Record<string, RsvpList>>(FILE_RSVP_LISTS)
+                .then(lists => {
+                    const list: RsvpList | undefined = lists[rsvp_id];
+                    if (!list) {
+                        return;
+                    }
+                    list.messages = list.messages.filter(m => m.message_id !== message_id);
+                    return saveJSON(FILE_RSVP_LISTS, lists);
+                });
+        });
+    }
+
+    deleteRsvpList(rsvp_id: string): Promise<void> {
+        return this._withLock(FILE_RSVP_LISTS, () => {
+            return loadJSON<Record<string, RsvpList>>(FILE_RSVP_LISTS)
+                .then(lists => {
+                    delete lists[rsvp_id];
+                    return saveJSON(FILE_RSVP_LISTS, lists);
                 });
         });
     }

--- a/main.ts
+++ b/main.ts
@@ -8,6 +8,8 @@ import GitHubService from './GitHubService';
 import { executeRollcall } from './command/rollcall';
 import MessageRouter, { ExtendedMessage } from './MessageRouter';
 import { escapeMarkdown } from './utils';
+import { normalizeSchedule, Rsvp, RsvpList } from './dao/DAO';
+import { keyboard, resolve, renderMessage } from './rsvp';
 
 // Command Handlers
 import hiHandler from './command/hi';
@@ -45,13 +47,15 @@ const steamEnabled = !!(process.env.STEAM_USERNAME && process.env.STEAM_PASSWORD
 // Scheduler
 setInterval(() => {
     dao.getScheduledRollcalls()
-        .then((schedules: Record<string, string>) => {
+        .then(schedules => {
             const now: Date = new Date();
-            for (const [chat_id, timeIso] of Object.entries<string>(schedules)) {
-                const scheduledTime: Date = new Date(timeIso);
+            for (const [chat_id, value] of Object.entries(schedules)) {
+                const schedule = normalizeSchedule(value);
+                const scheduledTime: Date = new Date(schedule.time);
                 if (scheduledTime <= now) {
                     console.log(`Executing scheduled rollcall for chat ${chat_id}`);
-                    executeRollcall(bot, parseInt(chat_id))
+                    executeRollcall(bot, parseInt(chat_id), { rsvp_id: schedule.rsvp_id })
+                        .then(() => closeScheduleConfirmation(parseInt(chat_id), schedule.rsvp_id))
                         .catch((err: Error) => console.error(`Error executing scheduled rollcall for ${chat_id}:`, err))
                         .finally(() => dao.removeScheduledRollcall(Number(chat_id)));
                 }
@@ -59,6 +63,85 @@ setInterval(() => {
         })
         .catch((err: Error) => console.error('Error checking schedules:', err));
 }, 30000);
+
+// When a schedule fires, the rollcall message takes over the shared RSVP list. Strip the
+// buttons from the now-stale confirmation message and detach it so only the rollcall stays live.
+const closeScheduleConfirmation = (chat_id: number, rsvp_id?: string): Promise<void> => {
+    if (!rsvp_id) {
+        return Promise.resolve();
+    }
+    return dao.getRsvpList(rsvp_id).then(list => {
+        if (!list) {
+            return;
+        }
+        const confirmation = list.messages.find(m => m.keyboard === 'schedule');
+        if (!confirmation) {
+            return;
+        }
+        return Promise.resolve()
+            .then(() => bot.editMessageReplyMarkup({ inline_keyboard: [] }, {
+                chat_id,
+                message_id: confirmation.message_id
+            }).catch(() => undefined))
+            .then(() => dao.removeRsvpMessage(rsvp_id, confirmation.message_id));
+    });
+};
+
+// Re-render every message attached to an RSVP list against the current rotation.
+const renderRsvpMessages = (list: RsvpList): Promise<unknown> => {
+    return dao.getRollcallPlayerUsernames(list.chat_id).then(rotation => {
+        const { groups } = resolve(rotation, list.entries);
+        return Promise.all(list.messages.map(ref =>
+            bot.editMessageText(renderMessage(ref.base_text, groups), {
+                chat_id: list.chat_id,
+                message_id: ref.message_id,
+                parse_mode: 'Markdown',
+                reply_markup: keyboard(ref.keyboard)
+            }).catch((err: Error) => {
+                // Telegram throws when the text is unchanged; that's harmless here.
+                if (!err.message?.includes('message is not modified')) {
+                    console.error(`Error updating RSVP message ${ref.message_id}:`, err);
+                }
+            })
+        ));
+    });
+};
+
+const handleRsvpCallback = (query: TelegramBot.CallbackQuery): void => {
+    const data: string | undefined = query.data;
+    const message: TelegramBot.Message | undefined = query.message;
+    if (!data || !data.startsWith('rsvp:') || !message) {
+        return;
+    }
+
+    const rsvp = data.substring('rsvp:'.length) as Rsvp;
+    if (!['yes', 'maybe', 'no'].includes(rsvp)) {
+        return;
+    }
+
+    const chat_id: number = message.chat.id;
+    const message_id: number = message.message_id;
+
+    dao.getRsvpListByMessage(chat_id, message_id)
+        .then(list => {
+            if (!list) {
+                return bot.answerCallbackQuery(query.id, { text: 'This RSVP has expired.' });
+            }
+
+            return dao.setRsvpEntry(list.rsvp_id, {
+                user_id: query.from.id,
+                name: query.from.first_name || query.from.username || 'someone',
+                username: query.from.username,
+                rsvp
+            })
+                .then(updated => updated ? renderRsvpMessages(updated) : undefined)
+                .then(() => bot.answerCallbackQuery(query.id));
+        })
+        .catch((err: Error) => {
+            console.error('Error handling RSVP callback:', err);
+            bot.answerCallbackQuery(query.id, { text: 'Something went wrong.' }).catch(() => undefined);
+        });
+};
 
 // Steam Service
 let steamService: SteamService | null = null;
@@ -149,6 +232,10 @@ bot.on('message', (msg: TelegramBot.Message) => {
     }
 
     router.handle(msg);
+});
+
+bot.on('callback_query', (query: TelegramBot.CallbackQuery) => {
+    handleRsvpCallback(query);
 });
 
 bot.on('error', (error: Error) => {

--- a/main.ts
+++ b/main.ts
@@ -9,7 +9,7 @@ import { executeRollcall } from './command/rollcall';
 import MessageRouter, { ExtendedMessage } from './MessageRouter';
 import { escapeMarkdown } from './utils';
 import { normalizeSchedule, Rsvp, RsvpList } from './dao/DAO';
-import { keyboard, resolve, renderMessage } from './rsvp';
+import { keyboard, resolve, renderMessage, entryFromUser } from './rsvp';
 
 // Command Handlers
 import hiHandler from './command/hi';
@@ -128,12 +128,7 @@ const handleRsvpCallback = (query: TelegramBot.CallbackQuery): void => {
                 return bot.answerCallbackQuery(query.id, { text: 'This RSVP has expired.' });
             }
 
-            return dao.setRsvpEntry(list.rsvp_id, {
-                user_id: query.from.id,
-                name: query.from.first_name || query.from.username || 'someone',
-                username: query.from.username,
-                rsvp
-            })
+            return dao.setRsvpEntry(list.rsvp_id, entryFromUser(query.from, rsvp))
                 .then(updated => updated ? renderRsvpMessages(updated) : undefined)
                 .then(() => bot.answerCallbackQuery(query.id));
         })

--- a/rsvp.ts
+++ b/rsvp.ts
@@ -1,6 +1,6 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { escapeMarkdown } from './utils';
-import { Rsvp, RsvpEntry } from './dao/DAO';
+import DAO, { Rsvp, RsvpEntry } from './dao/DAO';
 
 export type RsvpKeyboardKind = 'schedule' | 'rollcall';
 
@@ -119,11 +119,35 @@ const renderMessage = (baseText: string, groups: Record<Rsvp, string[]>): string
     return lists ? `${baseText}\n\n${lists}` : baseText;
 };
 
+// Build an RSVP entry from a Telegram user (used when seeding the initiator and when
+// recording a button tap).
+const entryFromUser = (user: TelegramBot.User, rsvp: Rsvp): RsvpEntry => ({
+    user_id: user.id,
+    name: user.first_name || user.username || 'someone',
+    username: user.username,
+    rsvp
+});
+
+// Strip the buttons from every message attached to a list and delete it, so its now-stale
+// confirmation can no longer record responses. Used when rescheduling or cancelling.
+const retireRsvpList = (bot: TelegramBot, dao: DAO, rsvp_id: string): Promise<void> =>
+    dao.getRsvpList(rsvp_id).then(list => {
+        const strips: Promise<unknown>[] = list
+            ? list.messages.map(ref => bot.editMessageReplyMarkup(
+                { inline_keyboard: [] },
+                { chat_id: list.chat_id, message_id: ref.message_id }
+            ).catch(() => undefined))
+            : [];
+        return Promise.all(strips).then(() => dao.deleteRsvpList(rsvp_id));
+    });
+
 export {
     keyboard,
     parseMention,
     displayName,
     resolve,
     renderLists,
-    renderMessage
+    renderMessage,
+    entryFromUser,
+    retireRsvpList
 };

--- a/rsvp.ts
+++ b/rsvp.ts
@@ -1,0 +1,129 @@
+import TelegramBot from 'node-telegram-bot-api';
+import { escapeMarkdown } from './utils';
+import { Rsvp, RsvpEntry } from './dao/DAO';
+
+export type RsvpKeyboardKind = 'schedule' | 'rollcall';
+
+const LABELS: Record<RsvpKeyboardKind, Record<Rsvp, string>> = {
+    schedule: { yes: "I'm in", maybe: 'Maybe', no: 'No' },
+    rollcall: { yes: 'Joining', maybe: 'Maybe later', no: 'No' }
+};
+
+const RSVP_EMOJI: Record<Rsvp, string> = {
+    yes: '🙋‍♂️',
+    maybe: '🤷‍♂️',
+    no: '🙅‍♂️'
+};
+
+// Build the inline keyboard for a message. The callback data is the same regardless
+// of the keyboard kind; only the visible labels differ.
+const keyboard = (kind: RsvpKeyboardKind): TelegramBot.InlineKeyboardMarkup => ({
+    inline_keyboard: [
+        (['yes', 'maybe', 'no'] as Rsvp[]).map(value => ({
+            text: LABELS[kind][value],
+            callback_data: `rsvp:${value}`
+        }))
+    ]
+});
+
+interface ParsedMention {
+    id?: number;
+    username?: string; // without leading @
+    display: string;
+}
+
+// A rotation player is stored either as `[Name](tg://user?id=123)` (text mention, has an id)
+// or as a plain `@username` string. Extract what we can to match against button tappers.
+const parseMention = (mention: string): ParsedMention => {
+    const match: RegExpMatchArray | null = mention.match(/^\[(.*)\]\(tg:\/\/user\?id=(\d+)\)$/);
+    if (match) {
+        return { id: Number(match[2]), display: match[1] };
+    }
+
+    if (mention.startsWith('@')) {
+        return { username: mention.substring(1), display: mention };
+    }
+
+    return { display: mention };
+};
+
+// Render a name so that it shows up in the message without pinging the user
+// (zero-width space breaks the @mention), matching command/admin/rollcall_get_players.ts.
+const displayName = (name: string): string => escapeMarkdown(name).replace('@', '@​');
+
+interface ResolvedPerson {
+    rsvp: Rsvp;
+    name: string;
+    // The original rotation mention string, if this person is a rotation player.
+    mention?: string;
+}
+
+export interface RsvpGroups {
+    groups: Record<Rsvp, string[]>; // display names per rsvp value
+    mentions: string[];             // rotation mention strings whose rsvp != 'no'
+}
+
+// Combine the live rotation roster with the explicit entries on the RSVP list.
+// Rotation players default to 'maybe'; explicit entries (incl. the seeded initiator)
+// override, and non-rotation tappers are appended as extra people.
+const resolve = (rotation: string[], entries: Record<string, RsvpEntry>): RsvpGroups => {
+    const people: ResolvedPerson[] = [];
+    const byId: Map<number, ResolvedPerson> = new Map();
+    const byUsername: Map<string, ResolvedPerson> = new Map();
+
+    rotation.forEach(mention => {
+        const parsed = parseMention(mention);
+        const person: ResolvedPerson = { rsvp: 'maybe', name: parsed.display, mention };
+        people.push(person);
+        if (parsed.id !== undefined) {
+            byId.set(parsed.id, person);
+        }
+        if (parsed.username) {
+            byUsername.set(parsed.username.toLowerCase(), person);
+        }
+    });
+
+    Object.values(entries).forEach(entry => {
+        const matched: ResolvedPerson | undefined =
+            byId.get(entry.user_id) ||
+            (entry.username ? byUsername.get(entry.username.toLowerCase()) : undefined);
+
+        if (matched) {
+            matched.rsvp = entry.rsvp;
+        } else {
+            people.push({ rsvp: entry.rsvp, name: entry.name });
+        }
+    });
+
+    const groups: Record<Rsvp, string[]> = { yes: [], maybe: [], no: [] };
+    const mentions: string[] = [];
+    people.forEach(person => {
+        groups[person.rsvp].push(displayName(person.name));
+        if (person.mention && person.rsvp !== 'no') {
+            mentions.push(person.mention);
+        }
+    });
+
+    return { groups, mentions };
+};
+
+// Build the 🙋‍♂️/🤷‍♂️/🙅‍♂️ block, omitting any group that has no members.
+const renderLists = (groups: Record<Rsvp, string[]>): string =>
+    (['yes', 'maybe', 'no'] as Rsvp[])
+        .filter(value => groups[value].length > 0)
+        .map(value => `${RSVP_EMOJI[value]} ${groups[value].join(' ')}`)
+        .join('\n');
+
+const renderMessage = (baseText: string, groups: Record<Rsvp, string[]>): string => {
+    const lists: string = renderLists(groups);
+    return lists ? `${baseText}\n\n${lists}` : baseText;
+};
+
+export {
+    keyboard,
+    parseMention,
+    displayName,
+    resolve,
+    renderLists,
+    renderMessage
+};


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive RSVP (response tracking) system that allows users to respond to scheduled rollcalls and regular rollcall messages with yes/maybe/no buttons. The system maintains shared RSVP lists across multiple messages and integrates with the existing rollcall scheduling feature.

## Key Changes

- **New RSVP data model** (`dao/DAO.ts`):
  - Added `RsvpList` interface to track responses, associated messages, and metadata
  - Added `RsvpEntry` interface for individual user responses with display names and usernames
  - Added `RsvpMessageRef` to link messages to their RSVP lists
  - Enhanced `ScheduledRollcall` to store rich metadata (time, rsvp_id, initiator_id) instead of just ISO strings
  - Added `normalizeSchedule()` helper for backward compatibility with legacy string-only schedules
  - Implemented TTL-based pruning (24 hours) to prevent unbounded file growth

- **RSVP list persistence** (`dao/DAO.ts`):
  - `createRsvpList()`: Create new RSVP lists with auto-generated IDs
  - `getRsvpList()`, `getRsvpListByMessage()`: Query lists by ID or message reference
  - `setRsvpEntry()`: Record user responses
  - `addRsvpMessage()`, `removeRsvpMessage()`: Manage message attachments to lists
  - `deleteRsvpList()`: Clean up expired lists

- **RSVP UI and rendering** (`rsvp.ts` - new file):
  - Inline keyboard with context-aware labels ("I'm in" for schedules, "Joining" for rollcalls)
  - Message rendering that combines rotation roster with explicit RSVP entries
  - Rotation player matching by user ID or Telegram username
  - Display name formatting that prevents accidental pings

- **Rollcall integration** (`command/rollcall.ts`):
  - Rollcall messages now include RSVP buttons and attach to shared lists
  - Support for inheriting entries from scheduled RSVP lists when triggered by timer
  - Seeding initiator as "yes" response

- **Schedule integration** (`command/schedule.ts`):
  - Schedule confirmation messages now show live RSVP counts with buttons
  - Stores rsvp_id and initiator_id on scheduled rollcalls
  - Creates RSVP list at schedule time instead of at execution time

- **Callback handling** (`main.ts`):
  - New `handleRsvpCallback()` to process button taps
  - `renderRsvpMessages()` to re-render all attached messages when entries change
  - `closeScheduleConfirmation()` to strip buttons from schedule message when rollcall fires
  - Scheduler updated to pass rsvp_id to rollcall execution and clean up confirmation

## Implementation Details

- RSVP lists are keyed by UUID and stored in a single JSON file with automatic pruning on write
- Messages can be attached to multiple RSVP lists (though typically one per list)
- Rotation players default to "maybe" and can be overridden by explicit entries
- Non-rotation users who tap buttons are added as extra entries
- Backward compatible with existing schedules that only store ISO time strings

https://claude.ai/code/session_01Msmji7u85wjWjrxpoSfFYK