### PR TITLE
Add CS2 game history tracking and /game_history (MariaDB)

### DIFF
--- a/SteamService.ts
+++ b/SteamService.ts
@@ -4,9 +4,23 @@ import TelegramBot from 'node-telegram-bot-api';
 import UserDAO, { UserSettings } from './dao/UserDAO';
 import ChatDAO, { ChatSettings } from './dao/ChatDAO';
 import GameUpdateDAO, { GameUpdate } from './dao/GameUpdateDAO';
+import GameHistoryDAO, { CurrentMatch, GameHistoryEntry, GameHistoryCoPlayer } from './dao/GameHistoryDAO';
+import RollcallPlayerDAO from './dao/RollcallPlayerDAO';
 import { escapeMarkdown } from './utils';
+import { parseMention } from './rsvp';
 import { save, readFile } from './dao/S3Client';
 import { saveSteamFile, readSteamFile } from './dao/Database';
+
+// A finished match with no further score progress is recorded once it has been idle
+// (CS2 not running, score unchanged) for this long. Overridable for tests.
+const MATCH_IDLE_MS = Number(process.env.MATCH_IDLE_MS) || 30 * 60 * 1000;
+
+// How often the idle-match sweep runs. Overridable for tests.
+const MATCH_SWEEP_MS = Number(process.env.MATCH_SWEEP_MS) || 60 * 1000;
+
+// How far a freshly reported round-total may dip below the running match total before we
+// treat it as a brand new match rather than out-of-order update noise.
+const RESET_TOLERANCE = 2;
 
 interface SteamOptions {
     dataDirectory?: string;
@@ -41,13 +55,19 @@ class SteamService {
     private userDao: UserDAO;
     private chatDao: ChatDAO;
     private gameUpdateDao: GameUpdateDAO;
+    private gameHistoryDao: GameHistoryDAO;
+    private rollcallPlayerDao: RollcallPlayerDAO;
     private steamToTelegram: Record<string, number>;
     private appIdCS2: number;
     private steamGuardCallback: ((code: string) => void) | null;
     private telegramNameCache: Record<string, { name: string; fetchedAt: number }> = {};
+    // Serialises read-modify-write of a (chat,user)'s match buffer so rapidly-arriving
+    // presence updates can't race (a score reset finalising before a continuation persists).
+    private matchLocks: Record<string, Promise<unknown>> = {};
     private friendsListLoaded: boolean = false;
     private adminUserId: string | undefined;
     private updateInterval: NodeJS.Timeout | null;
+    private matchSweepInterval: NodeJS.Timeout | null;
     private reconnectTimer: NodeJS.Timeout | null;
     private logOnOptions: any;
     private sharedSecret: string | undefined;
@@ -93,11 +113,14 @@ class SteamService {
         this.userDao = new UserDAO();
         this.chatDao = new ChatDAO();
         this.gameUpdateDao = new GameUpdateDAO();
+        this.gameHistoryDao = new GameHistoryDAO();
+        this.rollcallPlayerDao = new RollcallPlayerDAO();
         this.steamToTelegram = {};
         this.appIdCS2 = 730;
         this.steamGuardCallback = null;
         this.adminUserId = process.env.STEAM_ADMIN_TELEGRAM_USER_ID;
         this.updateInterval = null;
+        this.matchSweepInterval = null;
         this.reconnectTimer = null;
         this.logOnOptions = null;
         this.sharedSecret = undefined;
@@ -182,6 +205,12 @@ class SteamService {
 
         // Periodically update mappings in case new users register
         this.updateInterval = setInterval(() => this.updateUserMappings(), 60000);
+
+        // Finalise matches that have gone idle (the last match of a play session has no
+        // following reset to close it).
+        this.matchSweepInterval = setInterval(() => {
+            this.sweepIdleMatches().catch(err => console.error('Error sweeping idle matches:', err));
+        }, MATCH_SWEEP_MS);
     }
 
     private reconnect(delayMs = 30_000): void {
@@ -205,6 +234,10 @@ class SteamService {
         if (this.updateInterval) {
             clearInterval(this.updateInterval);
             this.updateInterval = null;
+        }
+        if (this.matchSweepInterval) {
+            clearInterval(this.matchSweepInterval);
+            this.matchSweepInterval = null;
         }
         this.client.logOff();
     }
@@ -265,6 +298,9 @@ class SteamService {
 
             const chats = await this.userDao.getUserChats(tgUserId);
             for (const chatId of chats) {
+                // The match (if any) is not over yet — a relaunch may continue it. Just mark
+                // it idle so the periodic sweep can finalise it after the idle window.
+                await this.markMatchNotPlaying(chatId, tgUserId);
                 await this.maybeCloseSession(chatId, tgUserId);
             }
             return;
@@ -273,22 +309,33 @@ class SteamService {
         console.debug(`User update: ${playerName} (${steamId}) is playing CS2`);
 
         // Extract game info from rich presence
-        let map: string | undefined, status: string | undefined, score: string | undefined;
+        let map: string | undefined, status: string | undefined, score: string | undefined, mode: string | undefined;
         const rp = user.rich_presence;
         if (Array.isArray(rp)) {
             map = rp.find((i: SteamRichPresenceItem) => i.key === 'game:map' || i.key === 'map')?.value;
             status = rp.find((i: SteamRichPresenceItem) => i.key === 'status')?.value;
             score = rp.find((i: SteamRichPresenceItem) => i.key === 'game:score' || i.key === 'score')?.value;
+            mode = rp.find((i: SteamRichPresenceItem) => i.key === 'game:mode' || i.key === 'mode')?.value;
         } else if (rp && typeof rp === 'object') {
             map = rp['game:map'] || rp['map'];
             status = rp['status'];
             score = rp['game:score'] || rp['score'];
+            mode = rp['game:mode'] || rp['mode'];
         }
 
         if (user.rich_presence_string) {
             // If we have a rich_presence_string, it's usually the most user-friendly summary
             status = user.rich_presence_string;
         }
+
+        // The game mode often isn't its own key; fall back to the status string.
+        if (!mode) {
+            mode = status;
+        }
+
+        // Keep the raw "16-14" before it's turned into emoji digits for display, so we can
+        // record it in history and compute win/loss/tie.
+        const rawScore: string | undefined = score ? score.replace(/[\[\]]/g, '').trim() : undefined;
 
         if (score) {
             score = this.formatScore(score);
@@ -305,6 +352,11 @@ class SteamService {
             console.debug(`No chats found for user ${tgUserId} (Steam ID: ${steamId}). Cannot publish update.`);
         }
         for (const chatId of chats) {
+            // Track match progress / boundaries regardless of the chat's live-update setting;
+            // history is a separate pull (/game_history) and the end-of-game notification is
+            // gated by steam_updates inside finalizeMatch.
+            await this.updateMatchState(chatId, tgUserId, { map, mode, rawScore, playerName });
+
             const chatSettings: ChatSettings = await this.chatDao.getChatSettings(chatId);
             if (chatSettings.steam_updates === false) {
                 console.debug(`Steam updates are disabled for chat ${chatId}. Skipping update for user ${tgUserId}.`);
@@ -445,6 +497,245 @@ class SteamService {
         const cleanScore = score.replace(/[\[\]]/g, '').trim();
         const numberEmojis = ['0️⃣', '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣'];
         return cleanScore.replace(/\d/g, (match: string) => numberEmojis[parseInt(match)]);
+    }
+
+    // Parse a raw "16-14" (or "16:14") score into its parts and round total.
+    parseRawScore(score?: string): { a: number; b: number; total: number } | null {
+        if (!score) return null;
+        const m = score.replace(/[\[\]]/g, '').trim().match(/^(\d+)\s*[-:]\s*(\d+)$/);
+        if (!m) return null;
+        const a = parseInt(m[1], 10);
+        const b = parseInt(m[2], 10);
+        return { a, b, total: a + b };
+    }
+
+    // 🏆/☠️/🤝 from a raw score (first part = player, second = opponents).
+    resultEmoji(score?: string): string {
+        const parsed = this.parseRawScore(score);
+        if (!parsed) return '•';
+        if (parsed.a > parsed.b) return '🏆';
+        if (parsed.a < parsed.b) return '☠️';
+        return '🤝';
+    }
+
+    // Pull map / mode / round-total out of a steam-user presence object (used when looking at
+    // other tracked players to decide who is in the same match).
+    private extractMapModeTotal(user: any): { map?: string; mode?: string; total?: number } {
+        let map: string | undefined, status: string | undefined, score: string | undefined, mode: string | undefined;
+        const rp = user?.rich_presence;
+        if (Array.isArray(rp)) {
+            map = rp.find((i: SteamRichPresenceItem) => i.key === 'game:map' || i.key === 'map')?.value;
+            status = rp.find((i: SteamRichPresenceItem) => i.key === 'status')?.value;
+            score = rp.find((i: SteamRichPresenceItem) => i.key === 'game:score' || i.key === 'score')?.value;
+            mode = rp.find((i: SteamRichPresenceItem) => i.key === 'game:mode' || i.key === 'mode')?.value;
+        } else if (rp && typeof rp === 'object') {
+            map = rp['game:map'] || rp['map'];
+            status = rp['status'];
+            score = rp['game:score'] || rp['score'];
+            mode = rp['game:mode'] || rp['mode'];
+        }
+        if (!mode) mode = status;
+        return { map, mode, total: this.parseRawScore(score)?.total };
+    }
+
+    // Run fn with exclusive access to a (chat,user)'s match buffer, chaining onto any in-flight
+    // operation for the same key so concurrent presence updates are applied in series.
+    private withMatchLock<T>(chatId: number, tgUserId: number, fn: () => Promise<T>): Promise<T> {
+        const key = `${chatId}_${tgUserId}`;
+        const prev = this.matchLocks[key] || Promise.resolve();
+        const run = prev.then(fn, fn);
+        this.matchLocks[key] = run.then(() => undefined, () => undefined);
+        return run;
+    }
+
+    // Update the persisted "current match" buffer for a (chat, user) from a presence tick,
+    // detecting match boundaries (score reset / map change / mode change) and accumulating
+    // co-players. Finalises the previous match when a boundary is crossed.
+    private updateMatchState(chatId: number, tgUserId: number, info: { map?: string; mode?: string; rawScore?: string; playerName?: string }): Promise<void> {
+      return this.withMatchLock(chatId, tgUserId, async () => {
+        try {
+            const { map, mode, rawScore, playerName } = info;
+            const cur = await this.gameHistoryDao.getCurrentMatch(chatId, tgUserId);
+            const newParsed = this.parseRawScore(rawScore);
+
+            if (cur) {
+                const mapChanged = !!(map && cur.map && map.toLowerCase() !== cur.map.toLowerCase());
+                const modeChanged = !!(mode && cur.mode && mode !== cur.mode);
+                const curParsed = this.parseRawScore(cur.max_score);
+                const scoreReset = !!(newParsed && curParsed && newParsed.total < curParsed.total - RESET_TOLERANCE);
+
+                if (!mapChanged && !modeChanged && !scoreReset) {
+                    // Continuation of the same match (incl. a relaunch resuming it).
+                    let max_score = cur.max_score;
+                    if (newParsed && (!curParsed || newParsed.total > curParsed.total)) {
+                        max_score = rawScore;
+                    }
+                    const matchMap = cur.map || map;
+                    const matchMode = cur.mode || mode;
+                    const incoming = await this.collectCoPlayers(chatId, tgUserId, matchMap, matchMode, this.parseRawScore(max_score)?.total);
+                    await this.gameHistoryDao.setCurrentMatch({
+                        chat_id: chatId,
+                        user_id: tgUserId,
+                        map: matchMap,
+                        mode: matchMode,
+                        max_score,
+                        player_name: playerName || cur.player_name,
+                        co_players: this.mergeCoPlayers(cur.co_players, incoming),
+                        started_at: cur.started_at,
+                        last_progress_at: new Date(),
+                        playing: true
+                    });
+                    return;
+                }
+
+                // Boundary: the previous match is finished. Record it, then start fresh.
+                await this.finalizeMatch(cur);
+            }
+
+            const coPlayers = await this.collectCoPlayers(chatId, tgUserId, map, mode, newParsed?.total);
+            const now = new Date();
+            await this.gameHistoryDao.setCurrentMatch({
+                chat_id: chatId,
+                user_id: tgUserId,
+                map,
+                mode,
+                max_score: rawScore,
+                player_name: playerName,
+                co_players: coPlayers,
+                started_at: now,
+                last_progress_at: now,
+                playing: true
+            });
+        } catch (err) {
+            console.error(`Error updating match state for user ${tgUserId} in chat ${chatId}:`, err);
+        }
+      });
+    }
+
+    // Other tracked users currently in the same match: playing CS2, same map + mode, scores
+    // not diverging too far, and sharing this chat. Returns them as resolved co-player names.
+    private async collectCoPlayers(chatId: number, tgUserId: number, map?: string, mode?: string, total?: number): Promise<GameHistoryCoPlayer[]> {
+        const result: GameHistoryCoPlayer[] = [];
+        const seen = new Set<number>();
+        for (const [otherSteamId, otherTgId] of Object.entries(this.steamToTelegram)) {
+            if (otherTgId === tgUserId || seen.has(otherTgId)) continue;
+            const otherUser = this.client.users[otherSteamId];
+            if (!otherUser || otherUser.gameid != this.appIdCS2) continue;
+
+            const other = this.extractMapModeTotal(otherUser);
+            if (map && other.map && map.toLowerCase() !== other.map.toLowerCase()) continue;
+            if (mode && other.mode && mode !== other.mode) continue;
+            if (total != null && other.total != null && Math.abs(total - other.total) > RESET_TOLERANCE) continue;
+
+            const otherChats = await this.userDao.getUserChats(otherTgId);
+            if (!otherChats.includes(chatId)) continue;
+
+            const name = await this.resolveCoPlayerName(chatId, otherTgId, otherUser.player_name);
+            result.push({ tg_user_id: otherTgId, name });
+            seen.add(otherTgId);
+        }
+        return result;
+    }
+
+    private mergeCoPlayers(existing: GameHistoryCoPlayer[], incoming: GameHistoryCoPlayer[]): GameHistoryCoPlayer[] {
+        const byId = new Map<number, GameHistoryCoPlayer>();
+        for (const p of existing || []) byId.set(p.tg_user_id, p);
+        for (const p of incoming || []) byId.set(p.tg_user_id, p);
+        return Array.from(byId.values());
+    }
+
+    // Resolve a co-player's display name: Telegram name → rollcall mention → Steam name → id.
+    private async resolveCoPlayerName(chatId: number, otherTgId: number, fallback?: string): Promise<string> {
+        const tgName = await this.getTelegramDisplayName(chatId, otherTgId);
+        if (tgName) return tgName;
+        try {
+            const rotation = await this.rollcallPlayerDao.getRollcallPlayerUsernames(chatId);
+            for (const mention of rotation) {
+                const parsed = parseMention(mention);
+                if (parsed.id === otherTgId) {
+                    return parsed.display;
+                }
+            }
+        } catch (err) {
+            console.debug(`Could not match co-player ${otherTgId} against rollcall:`, err);
+        }
+        return fallback || String(otherTgId);
+    }
+
+    // The user stopped playing CS2: don't finalise yet (a relaunch may continue the match),
+    // just mark it idle so the periodic sweep can finalise it after the idle window.
+    private markMatchNotPlaying(chatId: number, tgUserId: number): Promise<void> {
+        return this.withMatchLock(chatId, tgUserId, async () => {
+            try {
+                const cur = await this.gameHistoryDao.getCurrentMatch(chatId, tgUserId);
+                if (cur && cur.playing) {
+                    cur.playing = false;
+                    await this.gameHistoryDao.setCurrentMatch(cur);
+                }
+            } catch (err) {
+                console.error(`Error marking match not playing for user ${tgUserId} in chat ${chatId}:`, err);
+            }
+        });
+    }
+
+    // Record a finished match to history and (if the chat allows) post an end-of-game message.
+    private async finalizeMatch(match: CurrentMatch): Promise<void> {
+        const chatId = match.chat_id;
+        const tgUserId = match.user_id;
+        try {
+            if (match.max_score) {
+                const entry: GameHistoryEntry = {
+                    chat_id: chatId,
+                    user_id: tgUserId,
+                    mode: match.mode,
+                    map: match.map,
+                    score: match.max_score,
+                    co_players: match.co_players || [],
+                    started_at: match.started_at,
+                    ended_at: new Date()
+                };
+                await this.gameHistoryDao.addGameHistoryEntry(entry);
+
+                const chatSettings: ChatSettings = await this.chatDao.getChatSettings(chatId);
+                if (chatSettings.steam_updates !== false) {
+                    await this.postEndOfGameNotification(chatId, tgUserId, match);
+                }
+            }
+        } catch (err) {
+            console.error(`Failed to finalise match for user ${tgUserId} in chat ${chatId}:`, err);
+        } finally {
+            // Clear the buffer either way so we never record the same match twice.
+            await this.gameHistoryDao.deleteCurrentMatch(chatId, tgUserId).catch(() => {});
+        }
+    }
+
+    private async postEndOfGameNotification(chatId: number, tgUserId: number, match: CurrentMatch): Promise<void> {
+        const displayName = (await this.getTelegramDisplayName(chatId, tgUserId)) || match.player_name || 'Someone';
+        let text = `🏁 *${escapeMarkdown(displayName)}* finished a game`;
+        if (match.map) text += ` on ${escapeMarkdown(match.map)}`;
+        if (match.mode) text += ` (${escapeMarkdown(match.mode)})`;
+        if (match.max_score) text += `: ${escapeMarkdown(this.formatScore(match.max_score))} ${this.resultEmoji(match.max_score)}`;
+        await this.bot.sendMessage(chatId, text, { parse_mode: 'Markdown' });
+    }
+
+    // Finalise matches that have gone idle (CS2 not running, no score progress) past the window.
+    private async sweepIdleMatches(): Promise<void> {
+        try {
+            const cutoff = new Date(Date.now() - MATCH_IDLE_MS);
+            const idle = await this.gameHistoryDao.getIdleMatches(cutoff);
+            for (const match of idle) {
+                await this.withMatchLock(match.chat_id, match.user_id, async () => {
+                    // Re-read under the lock so we don't race a concurrent presence update.
+                    const cur = await this.gameHistoryDao.getCurrentMatch(match.chat_id, match.user_id);
+                    if (cur && !cur.playing && (Date.now() - new Date(cur.last_progress_at).getTime()) > MATCH_IDLE_MS) {
+                        console.log(`Match for user ${match.user_id} in chat ${match.chat_id} is idle; finalising.`);
+                        await this.finalizeMatch(cur);
+                    }
+                });
+            }
+        } catch (err) {
+            console.error('Error during idle match sweep:', err);
+        }
     }
 
     async maybeCloseSession(chatId: number, tgUserId: number): Promise<void> {

--- a/acceptance/docker-compose.yml
+++ b/acceptance/docker-compose.yml
@@ -69,6 +69,9 @@ services:
       STEAM_PASSWORD: testpass
       STEAM_ADMIN_TELEGRAM_USER_ID: "9999"
       STEAM_CONTROL_PORT: "9100"
+      # Finalise idle matches quickly so acceptance tests don't wait minutes.
+      MATCH_IDLE_MS: "6000"
+      MATCH_SWEEP_MS: "1000"
       GITHUB_API_BASE_URL: http://github-mock:8082
       GITHUB_REPO: acceptance/repo
       GITHUB_POLL_INTERVAL_MS: "1000"

--- a/acceptance/features/game_history.feature
+++ b/acceptance/features/game_history.feature
@@ -1,0 +1,103 @@
+Feature: CS2 game history
+  The bot records each finished CS2 match (map, mode, final score, co-players) and exposes it
+  via /game_history. A match ends on a score reset / map / mode change, or after the game has
+  been idle. When a chat has Steam updates enabled, each finished match is also announced.
+
+  Scenario: an idle game is recorded and announced, then shown in history
+    Given a chat with id 2101
+    And a user with id 5910 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000910"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000910"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000910" playing CS2 with score "16-14" on map "Inferno"
+    Then chat 2101 receives a Steam message containing "is playing Counter-Strike"
+    When Steam reports user "76561198000000910" stopped playing
+    Then chat 2101 eventually receives a new Steam message containing "finished a game"
+    And chat 2101 eventually receives a new Steam message containing "Inferno"
+    When the user sends "/game_history"
+    Then the bot reply contains "🏆"
+    And the bot reply contains "Inferno"
+    And the bot reply contains "16-14"
+
+  Scenario: a loss is recorded on a score reset and marked with a skull
+    Given a chat with id 2103
+    And a user with id 5912 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000912"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000912"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000912" playing CS2 with score "14-16" on map "Mirage"
+    And a moment passes
+    And Steam reports user "76561198000000912" playing CS2 with score "1-0" on map "Mirage"
+    Then chat 2103 eventually receives a new Steam message containing "finished a game"
+    When the user sends "/game_history"
+    Then the bot reply contains "☠️"
+    And the bot reply contains "14-16"
+
+  Scenario: a tie is marked with a handshake
+    Given a chat with id 2104
+    And a user with id 5913 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000913"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000913"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000913" playing CS2 with score "15-15" on map "Nuke"
+    And a moment passes
+    And Steam reports user "76561198000000913" playing CS2 with score "1-0" on map "Nuke"
+    Then chat 2104 eventually receives a new Steam message containing "finished a game"
+    When the user sends "/game_history"
+    Then the bot reply contains "🤝"
+    And the bot reply contains "15-15"
+
+  Scenario: a relaunch mid-match stays a single match
+    Given a chat with id 2105
+    And a user with id 5914 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000914"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000914"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000914" playing CS2 with score "10-5" on map "Inferno"
+    And Steam reports user "76561198000000914" stopped playing
+    And a moment passes
+    And Steam reports user "76561198000000914" playing CS2 with score "12-5" on map "Inferno"
+    And a moment passes
+    And Steam reports user "76561198000000914" playing CS2 with score "1-0" on map "Inferno"
+    Then chat 2105 eventually receives a new Steam message containing "finished a game"
+    When the user sends "/game_history"
+    Then the bot reply contains "12-5"
+
+  Scenario: a chat with Steam updates off records history but is not announced
+    Given a chat with id 2102
+    And a user with id 5920 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000920"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000920"
+    When the user sends "/steam_updates off"
+    Then the bot replies "Steam updates for this chat have been turned off."
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000920" playing CS2 with score "16-14" on map "Inferno"
+    Then no Steam message is posted to chat 2102
+    When Steam reports user "76561198000000920" playing CS2 with score "1-0" on map "Inferno"
+    Then no Steam message is posted to chat 2102
+    When the user sends "/game_history"
+    Then the bot reply contains "16-14"
+
+  Scenario: co-players in the same match are recorded
+    Given a chat with id 2106
+    When user 5930 sends "/steam_user_id 76561198000000930"
+    Then the bot reply contains "76561198000000930"
+    When user 5931 sends "/steam_user_id 76561198000000931"
+    Then the bot reply contains "76561198000000931"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000930" playing CS2 with score "5-3" on map "Inferno"
+    And Steam reports user "76561198000000931" playing CS2 with score "5-3" on map "Inferno"
+    And Steam reports user "76561198000000930" playing CS2 with score "6-3" on map "Inferno"
+    And Steam reports user "76561198000000931" stopped playing
+    And Steam reports user "76561198000000930" stopped playing
+    Then chat 2106 eventually receives a new Steam message containing "finished a game"
+    When user 5930 sends "/game_history"
+    Then the bot reply contains "with"
+
+  Scenario: a user with no history is told so
+    Given a chat with id 2107
+    And a user with id 5940 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000940"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000940"
+    When the user sends "/game_history"
+    Then the bot replies "No game history yet."

--- a/acceptance/features/steps/helpers.py
+++ b/acceptance/features/steps/helpers.py
@@ -33,6 +33,7 @@ _APP_TABLES: List[str] = [
     "telegram_user", "user_settings", "user_steam_id", "user_chat", "chat_settings",
     "rollcall_player", "rsvp_list", "rsvp_entry", "rsvp_message", "rollcall_schedule",
     "github_state", "game_update", "steam_storage",
+    "current_match_coplayer", "current_match", "game_history_coplayer", "game_history",
 ]
 
 # How long to wait for the bot to poll an update and produce a reply.

--- a/acceptance/features/steps/steam_steps.py
+++ b/acceptance/features/steps/steam_steps.py
@@ -36,6 +36,27 @@ def step_steam_playing_map(context: Context, steam_id: str, map_name: str) -> No
     })
 
 
+@when('a moment passes')
+def step_moment_passes(context: Context) -> None:
+    # Let the bot finish processing the previous presence update before the next one, so
+    # rapid score changes are applied in order (matches are seconds apart in reality).
+    time.sleep(1.5)
+
+
+@when('Steam reports user "{steam_id}" playing CS2 with score "{score}" on map "{map_name}"')
+def step_steam_playing_map_score(context: Context, steam_id: str, score: str, map_name: str) -> None:
+    _capture_steam_baseline(context)
+    helpers.steam_emit_user(steam_id, {
+        "player_name": "Gamer",
+        "gameid": 730,
+        "rich_presence": [
+            {"key": "game:map", "value": map_name},
+            {"key": "status", "value": "Competitive"},
+            {"key": "game:score", "value": score},
+        ],
+    })
+
+
 @when('Steam reports user "{steam_id}" playing CS2')
 def step_steam_playing(context: Context, steam_id: str) -> None:
     _capture_steam_baseline(context)
@@ -89,6 +110,24 @@ def step_steam_message_edited(context: Context, chat_id: int, expected: str) -> 
         time.sleep(helpers.POLL_INTERVAL)
     raise AssertionError(
         f"No editMessageText containing {expected!r} reached chat {chat_id}"
+    )
+
+
+@then('chat {chat_id:d} eventually receives a new Steam message containing "{expected}"')
+def step_chat_receives_new_steam(context: Context, chat_id: int, expected: str) -> None:
+    # Poll for a fresh sendMessage (e.g. the end-of-game notification), which may arrive a
+    # few seconds after an unrelated edit has already grown the outbox.
+    deadline: float = time.time() + helpers.REPLY_TIMEOUT
+    while time.time() < deadline:
+        outbox: List[Dict[str, Any]] = helpers.get_outbox(chat_id)
+        sends: List[Dict[str, Any]] = [
+            m for m in outbox if m["method"] == "sendMessage" and expected in m["text"]
+        ]
+        if sends:
+            return
+        time.sleep(helpers.POLL_INTERVAL)
+    raise AssertionError(
+        f"No sendMessage containing {expected!r} reached chat {chat_id}"
     )
 
 

--- a/command/game_history.ts
+++ b/command/game_history.ts
@@ -1,0 +1,61 @@
+import TelegramBot from 'node-telegram-bot-api';
+import { ExtendedMessage } from '../MessageRouter';
+import GameHistoryDAO, { GameHistoryEntry } from '../dao/GameHistoryDAO';
+import { escapeMarkdown, formatError } from '../utils';
+
+const dao = new GameHistoryDAO();
+
+// Keep the rendered reply comfortably under Telegram's 4096-character message cap.
+const MAX_MESSAGE_CHARS = 3900;
+
+// 🏆/☠️/🤝 from a raw "16-14" score (first part = player, second = opponents).
+const resultEmoji = (score?: string): string => {
+    const m = score ? score.replace(/[\[\]]/g, '').trim().match(/^(\d+)\s*[-:]\s*(\d+)$/) : null;
+    if (!m) return '•';
+    const a = parseInt(m[1], 10);
+    const b = parseInt(m[2], 10);
+    if (a > b) return '🏆';
+    if (a < b) return '☠️';
+    return '🤝';
+};
+
+// Render a name without pinging the user (zero-width space breaks the @mention).
+const safeName = (name: string): string => escapeMarkdown(name).replace('@', '@​');
+
+const renderLine = (entry: GameHistoryEntry): string => {
+    const parts: string[] = [];
+    if (entry.map) parts.push(escapeMarkdown(entry.map));
+    if (entry.mode) parts.push(escapeMarkdown(entry.mode));
+    if (entry.score) parts.push(escapeMarkdown(entry.score));
+    if (entry.co_players && entry.co_players.length > 0) {
+        parts.push(`with ${entry.co_players.map(p => safeName(p.name)).join(', ')}`);
+    }
+    return `${resultEmoji(entry.score)} ${parts.join(' · ')}`;
+};
+
+export default (bot: TelegramBot, msg: ExtendedMessage): void => {
+    dao.getGameHistory(msg.chat.id, msg.from!.id)
+        .then((entries: GameHistoryEntry[]) => {
+            if (entries.length === 0) {
+                msg.reply('No game history yet.');
+                return;
+            }
+
+            // Oldest → newest (newest at the bottom). Entries come back chronologically.
+            const lines = entries.map(renderLine);
+
+            // If the full list is too long, keep the most recent games that fit (drop the
+            // oldest) and note how many were omitted — newest still ends up at the bottom.
+            let kept = lines;
+            let omitted = 0;
+            while (kept.join('\n').length > MAX_MESSAGE_CHARS && kept.length > 1) {
+                kept = kept.slice(1);
+                omitted += 1;
+            }
+
+            const body = kept.join('\n');
+            const text = omitted > 0 ? `…${omitted} older games omitted\n${body}` : body;
+            msg.reply(text);
+        })
+        .catch((err: Error) => msg.reply(formatError(err)));
+};

--- a/dao/GameHistoryDAO.ts
+++ b/dao/GameHistoryDAO.ts
@@ -1,0 +1,201 @@
+import { ResultSetHeader, RowDataPacket } from 'mysql2/promise';
+import { query, withTransaction } from './Database';
+import { ensureTelegramUser } from './telegramUser';
+
+export interface GameHistoryCoPlayer {
+    tg_user_id: number;
+    name: string;
+}
+
+export interface GameHistoryEntry {
+    chat_id: number;
+    user_id: number;
+    mode?: string;
+    map?: string;
+    score?: string;        // raw final score, e.g. "16-14"
+    co_players: GameHistoryCoPlayer[];
+    started_at?: Date;
+    ended_at: Date;
+}
+
+// The match a (chat,user) is currently playing. Persisted so it survives session closes,
+// game relaunches mid-match, and bot restarts.
+export interface CurrentMatch {
+    chat_id: number;
+    user_id: number;
+    map?: string;
+    mode?: string;
+    max_score?: string;       // raw, highest score seen this match
+    player_name?: string;     // Steam display name, fallback for the notification
+    co_players: GameHistoryCoPlayer[];
+    started_at: Date;
+    last_progress_at: Date;
+    playing: boolean;
+}
+
+class GameHistoryDAO {
+    private _coPlayerFromRow(row: RowDataPacket): GameHistoryCoPlayer | null {
+        if (row.co_user_id == null) {
+            return null;
+        }
+        return { tg_user_id: Number(row.co_user_id), name: row.co_name ?? String(row.co_user_id) };
+    }
+
+    // The caller's finished matches for a chat, oldest first (newest at the bottom).
+    async getGameHistory(chat_id: number, user_id: number): Promise<GameHistoryEntry[]> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT h.id, h.chat_id, h.user_id, h.mode, h.map, h.score, h.started_at, h.ended_at, ' +
+            '       c.co_user_id, c.name AS co_name ' +
+            'FROM game_history h ' +
+            'LEFT JOIN game_history_coplayer c ON c.game_history_id = h.id ' +
+            'WHERE h.chat_id = :chat_id AND h.user_id = :user_id ' +
+            'ORDER BY h.id ASC',
+            { chat_id, user_id }
+        );
+
+        const byId = new Map<number, GameHistoryEntry>();
+        const order: number[] = [];
+        for (const row of rows) {
+            const id = Number(row.id);
+            let entry = byId.get(id);
+            if (!entry) {
+                entry = {
+                    chat_id: Number(row.chat_id),
+                    user_id: Number(row.user_id),
+                    mode: row.mode ?? undefined,
+                    map: row.map ?? undefined,
+                    score: row.score ?? undefined,
+                    co_players: [],
+                    started_at: row.started_at ?? undefined,
+                    ended_at: row.ended_at
+                };
+                byId.set(id, entry);
+                order.push(id);
+            }
+            const co = this._coPlayerFromRow(row);
+            if (co) {
+                entry.co_players.push(co);
+            }
+        }
+        return order.map(id => byId.get(id)!);
+    }
+
+    addGameHistoryEntry(entry: GameHistoryEntry): Promise<void> {
+        return withTransaction(async conn => {
+            await ensureTelegramUser(conn, entry.user_id);
+            const [res] = await conn.query<ResultSetHeader>(
+                'INSERT INTO game_history (chat_id, user_id, mode, map, score, started_at, ended_at) ' +
+                'VALUES (:chat_id, :user_id, :mode, :map, :score, :started_at, :ended_at)',
+                {
+                    chat_id: entry.chat_id,
+                    user_id: entry.user_id,
+                    mode: entry.mode ?? null,
+                    map: entry.map ?? null,
+                    score: entry.score ?? null,
+                    started_at: entry.started_at ?? null,
+                    ended_at: entry.ended_at
+                }
+            );
+            const historyId = res.insertId;
+            for (const co of entry.co_players) {
+                await conn.query(
+                    'INSERT INTO game_history_coplayer (game_history_id, co_user_id, name) ' +
+                    'VALUES (:game_history_id, :co_user_id, :name)',
+                    { game_history_id: historyId, co_user_id: co.tg_user_id, name: co.name ?? null }
+                );
+            }
+        });
+    }
+
+    private async _loadCurrentMatchCoPlayers(chat_id: number, user_id: number): Promise<GameHistoryCoPlayer[]> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT co_user_id, name FROM current_match_coplayer WHERE chat_id = :chat_id AND user_id = :user_id',
+            { chat_id, user_id }
+        );
+        return rows.map(r => ({ tg_user_id: Number(r.co_user_id), name: r.name ?? String(r.co_user_id) }));
+    }
+
+    private _matchFromRow(row: RowDataPacket, coPlayers: GameHistoryCoPlayer[]): CurrentMatch {
+        return {
+            chat_id: Number(row.chat_id),
+            user_id: Number(row.user_id),
+            map: row.map ?? undefined,
+            mode: row.mode ?? undefined,
+            max_score: row.max_score ?? undefined,
+            player_name: row.player_name ?? undefined,
+            co_players: coPlayers,
+            started_at: row.started_at,
+            last_progress_at: row.last_progress_at,
+            playing: !!row.playing
+        };
+    }
+
+    async getCurrentMatch(chat_id: number, user_id: number): Promise<CurrentMatch | null> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT chat_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing ' +
+            'FROM current_match WHERE chat_id = :chat_id AND user_id = :user_id',
+            { chat_id, user_id }
+        );
+        if (rows.length === 0) {
+            return null;
+        }
+        const coPlayers = await this._loadCurrentMatchCoPlayers(chat_id, user_id);
+        return this._matchFromRow(rows[0], coPlayers);
+    }
+
+    setCurrentMatch(match: CurrentMatch): Promise<void> {
+        return withTransaction(async conn => {
+            await ensureTelegramUser(conn, match.user_id);
+            // Replace the row (cascades co-players away), then re-insert it and the co-players.
+            await conn.query('DELETE FROM current_match WHERE chat_id = :chat_id AND user_id = :user_id',
+                { chat_id: match.chat_id, user_id: match.user_id });
+            await conn.query(
+                'INSERT INTO current_match (chat_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing) ' +
+                'VALUES (:chat_id, :user_id, :map, :mode, :max_score, :player_name, :started_at, :last_progress_at, :playing)',
+                {
+                    chat_id: match.chat_id,
+                    user_id: match.user_id,
+                    map: match.map ?? null,
+                    mode: match.mode ?? null,
+                    max_score: match.max_score ?? null,
+                    player_name: match.player_name ?? null,
+                    started_at: match.started_at,
+                    last_progress_at: match.last_progress_at,
+                    playing: match.playing ? 1 : 0
+                }
+            );
+            for (const co of match.co_players) {
+                await conn.query(
+                    'INSERT INTO current_match_coplayer (chat_id, user_id, co_user_id, name) ' +
+                    'VALUES (:chat_id, :user_id, :co_user_id, :name)',
+                    { chat_id: match.chat_id, user_id: match.user_id, co_user_id: co.tg_user_id, name: co.name ?? null }
+                );
+            }
+        });
+    }
+
+    deleteCurrentMatch(chat_id: number, user_id: number): Promise<void> {
+        return query<ResultSetHeader>(
+            'DELETE FROM current_match WHERE chat_id = :chat_id AND user_id = :user_id',
+            { chat_id, user_id }
+        ).then(() => undefined);
+    }
+
+    // Matches that are no longer playing and have not progressed since the cutoff. Used by the
+    // periodic sweep to finalise the trailing match of a play session (it has no following reset).
+    async getIdleMatches(cutoff: Date): Promise<CurrentMatch[]> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT chat_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing ' +
+            'FROM current_match WHERE playing = 0 AND last_progress_at < :cutoff',
+            { cutoff }
+        );
+        const matches: CurrentMatch[] = [];
+        for (const row of rows) {
+            const coPlayers = await this._loadCurrentMatchCoPlayers(Number(row.chat_id), Number(row.user_id));
+            matches.push(this._matchFromRow(row, coPlayers));
+        }
+        return matches;
+    }
+}
+
+export default GameHistoryDAO;

--- a/dao/schema.sql
+++ b/dao/schema.sql
@@ -131,3 +131,63 @@ CREATE TABLE IF NOT EXISTS steam_storage (
     contents LONGBLOB     NOT NULL,
     PRIMARY KEY (filename)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- The match a (chat,user) is currently playing. One row per (chat,user); replaced on
+-- write. Survives session closes and bot restarts so a match can span a game relaunch.
+-- A match is finished (and moved to game_history) on a score reset / map / mode change,
+-- or once it has been idle (not playing, no score progress) past the idle window.
+CREATE TABLE IF NOT EXISTS current_match (
+    chat_id          BIGINT       NOT NULL,
+    user_id          BIGINT       NOT NULL,
+    map              VARCHAR(64)  NULL,
+    mode             VARCHAR(255) NULL,
+    max_score        VARCHAR(64)  NULL,
+    player_name      VARCHAR(255) NULL,
+    started_at       DATETIME(3)  NOT NULL,
+    last_progress_at DATETIME(3)  NOT NULL,
+    playing          TINYINT(1)   NOT NULL,
+    PRIMARY KEY (chat_id, user_id),
+    KEY idx_current_match_idle (playing, last_progress_at),
+    CONSTRAINT fk_current_match_user FOREIGN KEY (user_id)
+        REFERENCES telegram_user (user_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Other tracked players seen in the same in-progress match. name is a point-in-time
+-- snapshot; co_user_id carries no FK so a co-player needn't be ensured every tick.
+CREATE TABLE IF NOT EXISTS current_match_coplayer (
+    chat_id    BIGINT       NOT NULL,
+    user_id    BIGINT       NOT NULL,
+    co_user_id BIGINT       NOT NULL,
+    name       VARCHAR(255) NULL,
+    PRIMARY KEY (chat_id, user_id, co_user_id),
+    CONSTRAINT fk_cmcp_match FOREIGN KEY (chat_id, user_id)
+        REFERENCES current_match (chat_id, user_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- A finished match. score is the raw "16-14" (player-opponent); win/loss/tie is derived
+-- from it. One row per finished match per (chat,user).
+CREATE TABLE IF NOT EXISTS game_history (
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    chat_id    BIGINT       NOT NULL,
+    user_id    BIGINT       NOT NULL,
+    mode       VARCHAR(255) NULL,
+    map        VARCHAR(64)  NULL,
+    score      VARCHAR(64)  NULL,
+    started_at DATETIME(3)  NULL,
+    ended_at   DATETIME(3)  NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_game_history_chat_user (chat_id, user_id),
+    CONSTRAINT fk_game_history_user FOREIGN KEY (user_id)
+        REFERENCES telegram_user (user_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Co-players recorded against a finished match. name is a point-in-time snapshot.
+CREATE TABLE IF NOT EXISTS game_history_coplayer (
+    game_history_id BIGINT       NOT NULL,
+    co_user_id      BIGINT       NOT NULL,
+    name            VARCHAR(255) NULL,
+    PRIMARY KEY (game_history_id, co_user_id),
+    CONSTRAINT fk_ghcp_history FOREIGN KEY (game_history_id)
+        REFERENCES game_history (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+

--- a/main.ts
+++ b/main.ts
@@ -25,6 +25,7 @@ import wingmanHandler from './command/wingman';
 import steamUserIdHandler from './command/steam_user_id';
 import steamUpdatesHandler from './command/steam_updates';
 import steamGuardHandler from './command/steam_guard';
+import gameHistoryHandler from './command/game_history';
 import githubNotifyHandler from './command/github_notify';
 import rollcallAddPlayerHandler from './command/admin/rollcall_add_player';
 import rollcallRemovePlayerHandler from './command/admin/rollcall_remove_player';
@@ -202,6 +203,9 @@ if (steamEnabled) {
     });
     router.route('steam_guard', steamGuardHandler, {
         helpText: 'Submit a Steam Guard code.'
+    });
+    router.route('game_history', gameHistoryHandler, {
+        helpText: 'Show your CS2 game history for this chat.'
     });
 }
 


### PR DESCRIPTION
Record every finished CS2 match (game mode, map, final score, and co-players
from the same game) so stats can be derived later, and expose it via a new
/game_history command that lists a chat's matches oldest-to-newest, one per
line, prefixed 🏆/☠️/🤝 derived from the raw score (first part = player, second
= opponents).

Match boundaries come from the score, not the Steam session: a match's score
only ticks up, so a score reset / map change / mode change ends one match and
starts the next, while a game relaunch mid-match just continues the same score
and stays one match. The trailing match of a play session is finalised once it
has been idle (not playing, no score progress) past MATCH_IDLE_MS. When a chat
has steam_updates enabled, each finished match is also announced with a fresh
message showing the final score.

Persistence follows the new per-entity MariaDB layer: a GameHistoryDAO backed
by game_history(+_coplayer) and current_match(+_coplayer) tables. Concurrent
presence updates for a (chat,user) are serialised with an in-memory lock so a
score reset can't finalise a match before an in-flight continuation persists
its higher score. The idle sweep queries idle matches directly from the DB.

Adds acceptance coverage for win/loss/tie, score-reset boundaries, a relaunch
staying one match, the steam_updates-off case, co-player recording, and empty
history, driven with MATCH_IDLE_MS/MATCH_SWEEP_MS in the test compose env.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014AqeqXsa9sGSaQSq5FckYG