### PR TITLE
Fix game-history match boundary edge cases (mode + per-account matches)

### DIFF
--- a/SteamService.ts
+++ b/SteamService.ts
@@ -279,9 +279,11 @@ class SteamService {
 
             const chats = await this.userDao.getUserChats(tgUserId);
             for (const chatId of chats) {
-                // The match (if any) is not over yet — a relaunch may continue it. Just mark
-                // it idle so the periodic sweep can finalise it after the idle window.
-                await this.markMatchNotPlaying(chatId, tgUserId);
+                // Mark THIS account's match idle — a match can't continue on another account,
+                // so a sibling account staying in CS2 is irrelevant. A relaunch on this same
+                // account will resume it; otherwise the sweep finalises it after the idle window.
+                await this.markMatchNotPlaying(chatId, steamId);
+                // The live message is per-user, so it only closes once no account is playing.
                 await this.maybeCloseSession(chatId, tgUserId);
             }
             return;
@@ -304,14 +306,20 @@ class SteamService {
             mode = rp['game:mode'] || rp['mode'];
         }
 
+        // The raw status value (e.g. "Competitive"), before the verbose summary overrides it.
+        const rawStatus: string | undefined = status;
+
         if (user.rich_presence_string) {
             // If we have a rich_presence_string, it's usually the most user-friendly summary
             status = user.rich_presence_string;
         }
 
-        // The game mode often isn't its own key; fall back to the status string.
+        // The game mode often isn't its own key; fall back to the raw status rich-presence
+        // value (e.g. "Competitive"), captured BEFORE rich_presence_string overrides status
+        // for display. Using the volatile summary here would make the mode change mid-match
+        // and spuriously split one match into many.
         if (!mode) {
-            mode = status;
+            mode = rawStatus;
         }
 
         // Keep the raw "16-14" before it's turned into emoji digits for display, so we can
@@ -336,7 +344,7 @@ class SteamService {
             // Track match progress / boundaries regardless of the chat's live-update setting;
             // history is a separate pull (/game_history) and the end-of-game notification is
             // gated by steam_updates inside finalizeMatch.
-            await this.updateMatchState(chatId, tgUserId, { map, mode, rawScore, playerName });
+            await this.updateMatchState(chatId, steamId, tgUserId, { map, mode, rawScore, playerName });
 
             const chatSettings: ChatSettings = await this.chatDao.getChatSettings(chatId);
             if (chatSettings.steam_updates === false) {
@@ -523,24 +531,25 @@ class SteamService {
         return { map, mode, total: this.parseRawScore(score)?.total };
     }
 
-    // Run fn with exclusive access to a (chat,user)'s match buffer, chaining onto any in-flight
-    // operation for the same key so concurrent presence updates are applied in series.
-    private withMatchLock<T>(chatId: number, tgUserId: number, fn: () => Promise<T>): Promise<T> {
-        const key = `${chatId}_${tgUserId}`;
+    // Run fn with exclusive access to a (chat,Steam account)'s match buffer, chaining onto any
+    // in-flight operation for the same key so concurrent presence updates are applied in series.
+    private withMatchLock<T>(chatId: number, steamId: string, fn: () => Promise<T>): Promise<T> {
+        const key = `${chatId}_${steamId}`;
         const prev = this.matchLocks[key] || Promise.resolve();
         const run = prev.then(fn, fn);
         this.matchLocks[key] = run.then(() => undefined, () => undefined);
         return run;
     }
 
-    // Update the persisted "current match" buffer for a (chat, user) from a presence tick,
-    // detecting match boundaries (score reset / map change / mode change) and accumulating
-    // co-players. Finalises the previous match when a boundary is crossed.
-    private updateMatchState(chatId: number, tgUserId: number, info: { map?: string; mode?: string; rawScore?: string; playerName?: string }): Promise<void> {
-      return this.withMatchLock(chatId, tgUserId, async () => {
+    // Update the persisted "current match" buffer for a (chat, Steam account) from a presence
+    // tick, detecting match boundaries (score reset / map change / mode change) and accumulating
+    // co-players. Finalises the previous match when a boundary is crossed. Keyed by Steam
+    // account so a user's linked accounts are tracked as independent matches.
+    private updateMatchState(chatId: number, steamId: string, tgUserId: number, info: { map?: string; mode?: string; rawScore?: string; playerName?: string }): Promise<void> {
+      return this.withMatchLock(chatId, steamId, async () => {
         try {
             const { map, mode, rawScore, playerName } = info;
-            const cur = await this.gameHistoryDao.getCurrentMatch(chatId, tgUserId);
+            const cur = await this.gameHistoryDao.getCurrentMatch(chatId, steamId);
             const newParsed = this.parseRawScore(rawScore);
 
             if (cur) {
@@ -560,6 +569,7 @@ class SteamService {
                     const incoming = await this.collectCoPlayers(chatId, tgUserId, matchMap, matchMode, this.parseRawScore(max_score)?.total);
                     await this.gameHistoryDao.setCurrentMatch({
                         chat_id: chatId,
+                        steam_id: steamId,
                         user_id: tgUserId,
                         map: matchMap,
                         mode: matchMode,
@@ -581,6 +591,7 @@ class SteamService {
             const now = new Date();
             await this.gameHistoryDao.setCurrentMatch({
                 chat_id: chatId,
+                steam_id: steamId,
                 user_id: tgUserId,
                 map,
                 mode,
@@ -592,7 +603,7 @@ class SteamService {
                 playing: true
             });
         } catch (err) {
-            console.error(`Error updating match state for user ${tgUserId} in chat ${chatId}:`, err);
+            console.error(`Error updating match state for user ${tgUserId} (Steam ID ${steamId}) in chat ${chatId}:`, err);
         }
       });
     }
@@ -647,18 +658,18 @@ class SteamService {
         return fallback || String(otherTgId);
     }
 
-    // The user stopped playing CS2: don't finalise yet (a relaunch may continue the match),
-    // just mark it idle so the periodic sweep can finalise it after the idle window.
-    private markMatchNotPlaying(chatId: number, tgUserId: number): Promise<void> {
-        return this.withMatchLock(chatId, tgUserId, async () => {
+    // A Steam account stopped playing CS2: don't finalise yet (a relaunch on the same account
+    // may continue the match), just mark it idle so the sweep can finalise it after the window.
+    private markMatchNotPlaying(chatId: number, steamId: string): Promise<void> {
+        return this.withMatchLock(chatId, steamId, async () => {
             try {
-                const cur = await this.gameHistoryDao.getCurrentMatch(chatId, tgUserId);
+                const cur = await this.gameHistoryDao.getCurrentMatch(chatId, steamId);
                 if (cur && cur.playing) {
                     cur.playing = false;
                     await this.gameHistoryDao.setCurrentMatch(cur);
                 }
             } catch (err) {
-                console.error(`Error marking match not playing for user ${tgUserId} in chat ${chatId}:`, err);
+                console.error(`Error marking match not playing for Steam ID ${steamId} in chat ${chatId}:`, err);
             }
         });
     }
@@ -690,7 +701,7 @@ class SteamService {
             console.error(`Failed to finalise match for user ${tgUserId} in chat ${chatId}:`, err);
         } finally {
             // Clear the buffer either way so we never record the same match twice.
-            await this.gameHistoryDao.deleteCurrentMatch(chatId, tgUserId).catch(() => {});
+            await this.gameHistoryDao.deleteCurrentMatch(chatId, match.steam_id).catch(() => {});
         }
     }
 
@@ -709,11 +720,11 @@ class SteamService {
             const cutoff = new Date(Date.now() - MATCH_IDLE_MS);
             const idle = await this.gameHistoryDao.getIdleMatches(cutoff);
             for (const match of idle) {
-                await this.withMatchLock(match.chat_id, match.user_id, async () => {
+                await this.withMatchLock(match.chat_id, match.steam_id, async () => {
                     // Re-read under the lock so we don't race a concurrent presence update.
-                    const cur = await this.gameHistoryDao.getCurrentMatch(match.chat_id, match.user_id);
+                    const cur = await this.gameHistoryDao.getCurrentMatch(match.chat_id, match.steam_id);
                     if (cur && !cur.playing && (Date.now() - new Date(cur.last_progress_at).getTime()) > MATCH_IDLE_MS) {
-                        console.log(`Match for user ${match.user_id} in chat ${match.chat_id} is idle; finalising.`);
+                        console.log(`Match for Steam ID ${match.steam_id} in chat ${match.chat_id} is idle; finalising.`);
                         await this.finalizeMatch(cur);
                     }
                 });
@@ -723,20 +734,21 @@ class SteamService {
         }
     }
 
+    // Is ANY of the user's mapped Steam accounts currently playing CS2? A user may register
+    // several Steam IDs, so a non-CS2 update from one doesn't mean they've stopped playing.
+    async isAnyAccountPlayingCS2(tgUserId: number): Promise<boolean> {
+        const settings = await this.userDao.getUserSettings(tgUserId);
+        const steamIds = settings.steam_ids || [];
+        return steamIds.some(sid => {
+            const user = this.client.users[sid];
+            // Check if playing CS2 (AppID 730)
+            return user && user.gameid == this.appIdCS2;
+        });
+    }
+
     async maybeCloseSession(chatId: number, tgUserId: number): Promise<void> {
         try {
-            // Check if ANY tracked steam ID for this user is playing CS2
-            // We need to fetch settings first to know all steam IDs
-            const settings = await this.userDao.getUserSettings(tgUserId);
-            const steamIds = settings.steam_ids || [];
-            
-            const isAnyPlaying = steamIds.some(sid => {
-                 const user = this.client.users[sid];
-                 // Check if playing CS2 (AppID 730)
-                 return user && user.gameid == this.appIdCS2;
-            });
-    
-            if (isAnyPlaying) {
+            if (await this.isAnyAccountPlayingCS2(tgUserId)) {
                  if (process.env.LOG_DEBUG) {
                      console.debug(`User ${tgUserId} has an active session on one of their accounts. Not closing.`);
                  }

--- a/acceptance/features/game_history.feature
+++ b/acceptance/features/game_history.feature
@@ -101,3 +101,37 @@ Feature: CS2 game history
     Then the bot replies "Your Steam user ID(s) has been set to 76561198000000940"
     When the user sends "/game_history"
     Then the bot replies "No game history yet."
+
+  Scenario: two linked Steam accounts are tracked as independent matches
+    # A match belongs to one Steam account and can't continue on another, so one account
+    # stopping finalises its own match even while the other account is still in a game.
+    Given a chat with id 2108
+    And a user with id 5950 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000950,76561198000000951"
+    Then the bot reply contains "76561198000000950"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000950" playing CS2 with score "16-14" on map "Inferno"
+    And Steam reports user "76561198000000951" playing CS2 with score "5-3" on map "Mirage"
+    And Steam reports user "76561198000000950" stopped playing
+    Then chat 2108 eventually receives a new Steam message containing "finished a game"
+    When Steam reports user "76561198000000951" stopped playing
+    And 8 seconds pass
+    When the user sends "/game_history"
+    Then the bot reply contains "16-14"
+    And the bot reply contains "5-3"
+
+  Scenario: a changing rich-presence summary does not split a match
+    Given a chat with id 2109
+    And a user with id 5960 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000960"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000960"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000960" playing CS2 summarised as "Competitive Inferno 5-3" with score "5-3" on map "Inferno"
+    And a moment passes
+    And Steam reports user "76561198000000960" playing CS2 summarised as "Competitive Inferno 8-3" with score "8-3" on map "Inferno"
+    And a moment passes
+    Then chat 2109 has not received a Steam message containing "finished a game"
+    When Steam reports user "76561198000000960" playing CS2 summarised as "Competitive Inferno 1-0" with score "1-0" on map "Inferno"
+    Then chat 2109 eventually receives a new Steam message containing "finished a game"
+    When the user sends "/game_history"
+    Then the bot reply contains "8-3"

--- a/acceptance/features/steps/steam_steps.py
+++ b/acceptance/features/steps/steam_steps.py
@@ -59,6 +59,29 @@ def step_steam_playing_map_score(context: Context, steam_id: str, score: str, ma
     })
 
 
+@when('{seconds:d} seconds pass')
+def step_seconds_pass(context: Context, seconds: int) -> None:
+    time.sleep(seconds)
+
+
+# A varying "summarised as" rich_presence_string with a stable "Competitive" status: the game
+# mode must come from the stable status, not the changing summary, or the match would split.
+# "summarised as" sits before "with score" so the existing score/map step can't greedily match.
+@when('Steam reports user "{steam_id}" playing CS2 summarised as "{summary}" with score "{score}" on map "{map_name}"')
+def step_steam_playing_map_score_summary(context: Context, steam_id: str, summary: str, score: str, map_name: str) -> None:
+    _capture_steam_baseline(context)
+    helpers.steam_emit_user(steam_id, {
+        "player_name": "Gamer",
+        "gameid": 730,
+        "rich_presence_string": summary,
+        "rich_presence": [
+            {"key": "game:map", "value": map_name},
+            {"key": "status", "value": "Competitive"},
+            {"key": "game:score", "value": score},
+        ],
+    })
+
+
 @when('Steam reports user "{steam_id}" playing CS2')
 def step_steam_playing(context: Context, steam_id: str) -> None:
     _capture_steam_baseline(context)
@@ -123,6 +146,15 @@ def step_latest_steam_still_contains(context: Context, chat_id: int, expected: s
         f"Latest Steam message in chat {chat_id} no longer contains {expected!r}; "
         f"a less-detailed update overwrote it. Latest text: {latest!r}"
     )
+
+
+@then('chat {chat_id:d} has not received a Steam message containing "{expected}"')
+def step_chat_has_not_received(context: Context, chat_id: int, expected: str) -> None:
+    # Immediate check (no wait): assert nothing matching has been posted yet. Pair with a
+    # preceding wait step to give a premature message time to appear if the bug were present.
+    outbox: List[Dict[str, Any]] = helpers.get_outbox(chat_id)
+    bad: List[str] = [m["text"] for m in outbox if m["method"] == "sendMessage" and expected in m["text"]]
+    assert not bad, f"Expected no Steam message containing {expected!r}, but got: {bad!r}"
 
 
 @then('the Steam message in chat {chat_id:d} is edited to contain "{expected}"')

--- a/dao/Database.ts
+++ b/dao/Database.ts
@@ -62,11 +62,35 @@ const splitStatements = (sql: string): string[] =>
         .map(stmt => stmt.trim())
         .filter(stmt => stmt.length > 0);
 
-// Create any missing tables. Idempotent (every statement is CREATE TABLE IF NOT EXISTS).
+// One-off, idempotent migration: current_match(+_coplayer) were originally keyed by
+// (chat_id,user_id) and are now keyed by (chat_id,steam_id). They hold only transient
+// in-flight match state, so when the old shape is detected (table exists without a steam_id
+// column) we drop them and let the CREATE TABLE statements below rebuild them. Runs once —
+// after the rebuild the steam_id column exists, so the guard is false on later startups.
+const migrateLegacyCurrentMatch = async (conn: PoolConnection): Promise<void> => {
+    const [rows] = await conn.query<RowDataPacket[]>(
+        'SELECT ' +
+        "(SELECT COUNT(*) FROM information_schema.TABLES " +
+        " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'current_match') AS tbl, " +
+        "(SELECT COUNT(*) FROM information_schema.COLUMNS " +
+        " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'current_match' AND COLUMN_NAME = 'steam_id') AS col"
+    );
+    const tableExists = Number(rows[0]?.tbl) > 0;
+    const hasSteamId = Number(rows[0]?.col) > 0;
+    if (tableExists && !hasSteamId) {
+        console.log('Rebuilding legacy current_match tables for per-Steam-account match keying.');
+        await conn.query('DROP TABLE IF EXISTS current_match_coplayer');
+        await conn.query('DROP TABLE IF EXISTS current_match');
+    }
+};
+
+// Create any missing tables. Idempotent (every statement is CREATE TABLE IF NOT EXISTS, plus
+// a guarded one-off rebuild of the transient current_match tables when their shape changed).
 export const ensureSchema = async (): Promise<void> => {
     const ddl = readFileSync(join(import.meta.dirname, 'schema.sql'), 'utf-8');
     const conn = await getPool().getConnection();
     try {
+        await migrateLegacyCurrentMatch(conn);
         for (const statement of splitStatements(ddl)) {
             await conn.query(statement);
         }

--- a/dao/GameHistoryDAO.ts
+++ b/dao/GameHistoryDAO.ts
@@ -18,10 +18,14 @@ export interface GameHistoryEntry {
     ended_at: Date;
 }
 
-// The match a (chat,user) is currently playing. Persisted so it survives session closes,
-// game relaunches mid-match, and bot restarts.
+// The match a Steam account is currently playing, surfaced in a chat. Keyed by
+// (chat,steam_id) — a match belongs to one Steam account and can't continue on another, so a
+// user's linked accounts each get their own row. user_id is carried for history attribution
+// and the end-of-game notification. Persisted so it survives session closes, game relaunches
+// mid-match, and bot restarts.
 export interface CurrentMatch {
     chat_id: number;
+    steam_id: string;
     user_id: number;
     map?: string;
     mode?: string;
@@ -107,10 +111,10 @@ class GameHistoryDAO {
         });
     }
 
-    private async _loadCurrentMatchCoPlayers(chat_id: number, user_id: number): Promise<GameHistoryCoPlayer[]> {
+    private async _loadCurrentMatchCoPlayers(chat_id: number, steam_id: string): Promise<GameHistoryCoPlayer[]> {
         const rows = await query<RowDataPacket[]>(
-            'SELECT co_user_id, name FROM current_match_coplayer WHERE chat_id = :chat_id AND user_id = :user_id',
-            { chat_id, user_id }
+            'SELECT co_user_id, name FROM current_match_coplayer WHERE chat_id = :chat_id AND steam_id = :steam_id',
+            { chat_id, steam_id }
         );
         return rows.map(r => ({ tg_user_id: Number(r.co_user_id), name: r.name ?? String(r.co_user_id) }));
     }
@@ -118,6 +122,7 @@ class GameHistoryDAO {
     private _matchFromRow(row: RowDataPacket, coPlayers: GameHistoryCoPlayer[]): CurrentMatch {
         return {
             chat_id: Number(row.chat_id),
+            steam_id: String(row.steam_id),
             user_id: Number(row.user_id),
             map: row.map ?? undefined,
             mode: row.mode ?? undefined,
@@ -130,16 +135,16 @@ class GameHistoryDAO {
         };
     }
 
-    async getCurrentMatch(chat_id: number, user_id: number): Promise<CurrentMatch | null> {
+    async getCurrentMatch(chat_id: number, steam_id: string): Promise<CurrentMatch | null> {
         const rows = await query<RowDataPacket[]>(
-            'SELECT chat_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing ' +
-            'FROM current_match WHERE chat_id = :chat_id AND user_id = :user_id',
-            { chat_id, user_id }
+            'SELECT chat_id, steam_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing ' +
+            'FROM current_match WHERE chat_id = :chat_id AND steam_id = :steam_id',
+            { chat_id, steam_id }
         );
         if (rows.length === 0) {
             return null;
         }
-        const coPlayers = await this._loadCurrentMatchCoPlayers(chat_id, user_id);
+        const coPlayers = await this._loadCurrentMatchCoPlayers(chat_id, steam_id);
         return this._matchFromRow(rows[0], coPlayers);
     }
 
@@ -147,13 +152,14 @@ class GameHistoryDAO {
         return withTransaction(async conn => {
             await ensureTelegramUser(conn, match.user_id);
             // Replace the row (cascades co-players away), then re-insert it and the co-players.
-            await conn.query('DELETE FROM current_match WHERE chat_id = :chat_id AND user_id = :user_id',
-                { chat_id: match.chat_id, user_id: match.user_id });
+            await conn.query('DELETE FROM current_match WHERE chat_id = :chat_id AND steam_id = :steam_id',
+                { chat_id: match.chat_id, steam_id: match.steam_id });
             await conn.query(
-                'INSERT INTO current_match (chat_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing) ' +
-                'VALUES (:chat_id, :user_id, :map, :mode, :max_score, :player_name, :started_at, :last_progress_at, :playing)',
+                'INSERT INTO current_match (chat_id, steam_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing) ' +
+                'VALUES (:chat_id, :steam_id, :user_id, :map, :mode, :max_score, :player_name, :started_at, :last_progress_at, :playing)',
                 {
                     chat_id: match.chat_id,
+                    steam_id: match.steam_id,
                     user_id: match.user_id,
                     map: match.map ?? null,
                     mode: match.mode ?? null,
@@ -166,18 +172,18 @@ class GameHistoryDAO {
             );
             for (const co of match.co_players) {
                 await conn.query(
-                    'INSERT INTO current_match_coplayer (chat_id, user_id, co_user_id, name) ' +
-                    'VALUES (:chat_id, :user_id, :co_user_id, :name)',
-                    { chat_id: match.chat_id, user_id: match.user_id, co_user_id: co.tg_user_id, name: co.name ?? null }
+                    'INSERT INTO current_match_coplayer (chat_id, steam_id, co_user_id, name) ' +
+                    'VALUES (:chat_id, :steam_id, :co_user_id, :name)',
+                    { chat_id: match.chat_id, steam_id: match.steam_id, co_user_id: co.tg_user_id, name: co.name ?? null }
                 );
             }
         });
     }
 
-    deleteCurrentMatch(chat_id: number, user_id: number): Promise<void> {
+    deleteCurrentMatch(chat_id: number, steam_id: string): Promise<void> {
         return query<ResultSetHeader>(
-            'DELETE FROM current_match WHERE chat_id = :chat_id AND user_id = :user_id',
-            { chat_id, user_id }
+            'DELETE FROM current_match WHERE chat_id = :chat_id AND steam_id = :steam_id',
+            { chat_id, steam_id }
         ).then(() => undefined);
     }
 
@@ -185,13 +191,13 @@ class GameHistoryDAO {
     // periodic sweep to finalise the trailing match of a play session (it has no following reset).
     async getIdleMatches(cutoff: Date): Promise<CurrentMatch[]> {
         const rows = await query<RowDataPacket[]>(
-            'SELECT chat_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing ' +
+            'SELECT chat_id, steam_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing ' +
             'FROM current_match WHERE playing = 0 AND last_progress_at < :cutoff',
             { cutoff }
         );
         const matches: CurrentMatch[] = [];
         for (const row of rows) {
-            const coPlayers = await this._loadCurrentMatchCoPlayers(Number(row.chat_id), Number(row.user_id));
+            const coPlayers = await this._loadCurrentMatchCoPlayers(Number(row.chat_id), String(row.steam_id));
             matches.push(this._matchFromRow(row, coPlayers));
         }
         return matches;

--- a/dao/schema.sql
+++ b/dao/schema.sql
@@ -132,12 +132,17 @@ CREATE TABLE IF NOT EXISTS steam_storage (
     PRIMARY KEY (filename)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- The match a (chat,user) is currently playing. One row per (chat,user); replaced on
--- write. Survives session closes and bot restarts so a match can span a game relaunch.
--- A match is finished (and moved to game_history) on a score reset / map / mode change,
--- or once it has been idle (not playing, no score progress) past the idle window.
+-- The match a Steam account is currently playing, surfaced in a given chat. Keyed by
+-- (chat,steam_id) — NOT by user — because a match belongs to one Steam account and cannot
+-- continue on another; a user with several linked accounts gets one row per account, so a
+-- stop on one account never disturbs another's match. user_id is carried for history
+-- attribution and the end-of-game notification. One row per (chat,steam_id); replaced on
+-- write. Survives session closes and bot restarts so a match can span a game relaunch. A
+-- match is finished (and moved to game_history) on a score reset / map / mode change, or
+-- once it has been idle (not playing, no score progress) past the idle window.
 CREATE TABLE IF NOT EXISTS current_match (
     chat_id          BIGINT       NOT NULL,
+    steam_id         VARCHAR(32)  NOT NULL,
     user_id          BIGINT       NOT NULL,
     map              VARCHAR(64)  NULL,
     mode             VARCHAR(255) NULL,
@@ -146,7 +151,7 @@ CREATE TABLE IF NOT EXISTS current_match (
     started_at       DATETIME(3)  NOT NULL,
     last_progress_at DATETIME(3)  NOT NULL,
     playing          TINYINT(1)   NOT NULL,
-    PRIMARY KEY (chat_id, user_id),
+    PRIMARY KEY (chat_id, steam_id),
     KEY idx_current_match_idle (playing, last_progress_at),
     CONSTRAINT fk_current_match_user FOREIGN KEY (user_id)
         REFERENCES telegram_user (user_id) ON DELETE CASCADE
@@ -156,12 +161,12 @@ CREATE TABLE IF NOT EXISTS current_match (
 -- snapshot; co_user_id carries no FK so a co-player needn't be ensured every tick.
 CREATE TABLE IF NOT EXISTS current_match_coplayer (
     chat_id    BIGINT       NOT NULL,
-    user_id    BIGINT       NOT NULL,
+    steam_id   VARCHAR(32)  NOT NULL,
     co_user_id BIGINT       NOT NULL,
     name       VARCHAR(255) NULL,
-    PRIMARY KEY (chat_id, user_id, co_user_id),
-    CONSTRAINT fk_cmcp_match FOREIGN KEY (chat_id, user_id)
-        REFERENCES current_match (chat_id, user_id) ON DELETE CASCADE
+    PRIMARY KEY (chat_id, steam_id, co_user_id),
+    CONSTRAINT fk_cmcp_match FOREIGN KEY (chat_id, steam_id)
+        REFERENCES current_match (chat_id, steam_id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- A finished match. score is the raw "16-14" (player-opponent); win/loss/tie is derived


### PR DESCRIPTION
Follow-up to #30, addressing two match-boundary edge cases (one I found, one from the Codex review on #30).

## 1. Game mode derived from a volatile summary string (bug I found)
When CS2 doesn't supply a `game:mode` key, the mode fell back to `status` — but `status` had already been overwritten with `rich_presence_string`, the free-form summary. That summary changes during a match (status/score baked in), and the match-boundary detector treats a **mode change as a new match**, so one match would be split into many — spamming both `game_history` and end-of-game notifications.

Fix: capture the raw `status` rich-presence value (e.g. `"Competitive"`) **before** the `rich_presence_string` override and use that for the mode fallback. Display still uses the verbose summary.

## 2. Track the match per Steam account, not per user (replaces the all-accounts gate)
The Codex review on #30 flagged that a non-CS2 update from one of a user's linked Steam IDs marked the single per-user `current_match` as not-playing while another account was still in CS2. My first attempt gated this on "is any account still in CS2" — but that premise can't happen: **a match belongs to one Steam account and can't continue on another**, so a sibling account being in CS2 never means it's continuing this match.

Proper fix: key match state by **`(chat, steam_id)`** instead of `(chat, user)`. Each linked account is now tracked as an independent match:
- A stop on one account finalises only *that* account's match — correctly, and regardless of the other account.
- The contrived account-sharing case (two accounts genuinely in the same game) records two independent entries rather than corrupting one buffer.
- `current_match` / `current_match_coplayer` are keyed by `(chat, steam_id)` and carry `user_id` for per-user history attribution + notifications. The live message and history stay per-user.

The non-CS2 branch now simply marks *this account's* match idle (a relaunch on the same account resumes it; otherwise the sweep finalises it). The all-accounts check stays only where it belongs — closing the per-user live message in `maybeCloseSession`.

## Schema migration (automatic)
`current_match` / `current_match_coplayer` changed shape (now keyed by `steam_id`). Since `ensureSchema` is `CREATE TABLE IF NOT EXISTS`-only, it gains a **guarded, idempotent one-off rebuild**: on startup, if the old `(chat_id,user_id)`-keyed table is detected (no `steam_id` column), the two transient tables are dropped and recreated with the new shape. They hold only in-flight match state, so this loses nothing durable and runs exactly once — no manual step for existing #30 deployments. Fresh DBs and the acceptance suite are unaffected.

## Tests
Two new acceptance scenarios:
- **Two linked Steam accounts tracked as independent matches** — one account stopping finalises its own match while the other is still playing, and both end up in `/game_history`.
- **A changing rich-presence summary does not split a match** — varying `rich_presence_string` with a stable status stays a single match (locks in fix #1).

Full suite green on the rebased branch: 15 features / 49 scenarios / 314 steps. (The migration's drop-path isn't exercised by acceptance, which uses a fresh DB; the guard is small and idempotent.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)