### PR TITLE
Lock the RSVP list row in setRsvpEntry to avoid stale renders

### DIFF
--- a/dao/RsvpDAO.ts
+++ b/dao/RsvpDAO.ts
@@ -109,7 +109,10 @@ class RsvpDAO {
 
     setRsvpEntry(rsvp_id: number, entry: RsvpEntry): Promise<RsvpList | undefined> {
         return withTransaction(async conn => {
-            const [listRows] = await conn.query<RowDataPacket[]>('SELECT id FROM rsvp_list WHERE id = :id', { id: rsvp_id });
+            // Lock the list row so concurrent RSVP taps serialise on it. Without the lock,
+            // each transaction's snapshot is fixed before the other commits, and the reload
+            // below can miss the other entry — rendering a stale list over the Telegram message.
+            const [listRows] = await conn.query<RowDataPacket[]>('SELECT id FROM rsvp_list WHERE id = :id FOR UPDATE', { id: rsvp_id });
             if (listRows.length === 0) {
                 return undefined;
             }


### PR DESCRIPTION
## Summary
Fixes a concurrency race in `setRsvpEntry` (flagged by Codex review on #32).

Under InnoDB's default REPEATABLE READ isolation, two people tapping RSVP buttons at the same
time each open a transaction whose read snapshot is fixed before the other commits. Both entry
inserts succeed, but the list reloaded by `_loadRsvpList` for rendering can miss the other
transaction's entry — so whichever callback renders last overwrites the Telegram message with an
incomplete RSVP list until a later action refreshes it.

The fix takes a locking read (`SELECT ... FOR UPDATE`) on the `rsvp_list` row at the start of the
`setRsvpEntry` transaction. Concurrent taps now serialise on that row, so by the time the second
transaction reloads the list it sees the other's committed entry. The change is one line plus a
comment; `addRsvpMessage` is left as-is (it returns no rendered list and its inserts don't conflict).

## Verification
- `tsc --noEmit` + `npm run build` clean.
- The RSVP flows are exercised by the acceptance suite (rollcall/schedule features) in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cfH26kwgjSSEA9Rkog7XR

---
_Generated by [Claude Code](https://claude.ai/code/session_014cfH26kwgjSSEA9Rkog7XR)_