### PR TITLE
Fix Steam presence updates to prevent less-detailed messages from overwriting detailed ones

### DIFF
--- a/SteamService.ts
+++ b/SteamService.ts
@@ -396,7 +396,11 @@ class SteamService {
                 // Check if the new update is less detailed than the previous one.
                 // We should NOT replace a more detailed message with a less detailed one
                 // UNLESS the map or game mode/status or game itself has changed.
-                const gameChanged = info.gameId !== oldInfo.gameId;
+                // Compare as strings: the live gameId comes straight from steam-user (a
+                // string like "730"), while the stored one is reconstructed from the DB. A
+                // raw !== would always report a change on a type mismatch, disabling the
+                // less-detailed-update guard below.
+                const gameChanged = String(info.gameId ?? '') !== String(oldInfo.gameId ?? '');
                 const mapChanged = info.map && info.map !== oldInfo.map;
                 const meaningfulStatusChanged = info.status && info.status !== oldInfo.status && !this.isGenericStatus(info.status);
                 

--- a/acceptance/features/steam_game_updates.feature
+++ b/acceptance/features/steam_game_updates.feature
@@ -13,6 +13,18 @@ Feature: Steam game-presence updates
     When Steam reports user "76561198000000010" stopped playing
     Then the Steam message in chat 2001 is edited to contain "🔴"
 
+  Scenario: a less-detailed update does not overwrite a more-detailed one
+    Given a chat with id 2003
+    And a user with id 5903 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000030"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000030"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000030" playing CS2 with score "16-14" on map "Inferno"
+    Then chat 2003 receives a Steam message containing "Score:"
+    When a moment passes
+    And Steam reports user "76561198000000030" playing CS2 with no details
+    Then the latest Steam message in chat 2003 still contains "Score:"
+
   Scenario: a chat that disabled updates receives nothing
     Given a chat with id 2002
     And a user with id 5902 and first name "Tester"

--- a/acceptance/features/steps/steam_steps.py
+++ b/acceptance/features/steps/steam_steps.py
@@ -28,7 +28,9 @@ def step_steam_playing_map(context: Context, steam_id: str, map_name: str) -> No
     _capture_steam_baseline(context)
     helpers.steam_emit_user(steam_id, {
         "player_name": "Gamer",
-        "gameid": 730,
+        # The real steam-user library reports gameid as a string ("730"), so the mock
+        # must too — a numeric 730 would not exercise the type-sensitive diff logic.
+        "gameid": "730",
         "rich_presence": [
             {"key": "game:map", "value": map_name},
             {"key": "status", "value": "Competitive"},
@@ -48,7 +50,7 @@ def step_steam_playing_map_score(context: Context, steam_id: str, score: str, ma
     _capture_steam_baseline(context)
     helpers.steam_emit_user(steam_id, {
         "player_name": "Gamer",
-        "gameid": 730,
+        "gameid": "730",
         "rich_presence": [
             {"key": "game:map", "value": map_name},
             {"key": "status", "value": "Competitive"},
@@ -60,7 +62,15 @@ def step_steam_playing_map_score(context: Context, steam_id: str, score: str, ma
 @when('Steam reports user "{steam_id}" playing CS2')
 def step_steam_playing(context: Context, steam_id: str) -> None:
     _capture_steam_baseline(context)
-    helpers.steam_emit_user(steam_id, {"player_name": "Gamer", "gameid": 730})
+    helpers.steam_emit_user(steam_id, {"player_name": "Gamer", "gameid": "730"})
+
+
+@when('Steam reports user "{steam_id}" playing CS2 with no details')
+def step_steam_playing_no_details(context: Context, steam_id: str) -> None:
+    # A bare "playing CS2" presence with no map/status/score. This must not be allowed to
+    # overwrite a more-detailed message that is already on screen for the same session.
+    _capture_steam_baseline(context)
+    helpers.steam_emit_user(steam_id, {"player_name": "Gamer", "gameid": "730"})
 
 
 @when('Steam reports user "{steam_id}" stopped playing')
@@ -95,6 +105,24 @@ def step_no_steam_message(context: Context, chat_id: int) -> None:
     new: List[Dict[str, Any]] = helpers.expect_no_new_message(chat_id, baseline)
     sends: List[str] = [m["text"] for m in new if m["method"] == "sendMessage"]
     assert not sends, f"Expected no Steam message, but got: {sends!r}"
+
+
+@then('the latest Steam message in chat {chat_id:d} still contains "{expected}"')
+def step_latest_steam_still_contains(context: Context, chat_id: int, expected: str) -> None:
+    # The most recent thing the user sees in the chat (whether the original sendMessage or a
+    # later editMessageText) must still carry the detailed info. If a less-detailed update was
+    # wrongly allowed to overwrite it, the latest outbox entry would be the downgraded text.
+    time.sleep(2)
+    outbox: List[Dict[str, Any]] = helpers.get_outbox(chat_id)
+    msgs: List[Dict[str, Any]] = [
+        m for m in outbox if m["method"] in ("sendMessage", "editMessageText")
+    ]
+    assert msgs, f"No Steam messages reached chat {chat_id}"
+    latest: str = msgs[-1]["text"]
+    assert expected in latest, (
+        f"Latest Steam message in chat {chat_id} no longer contains {expected!r}; "
+        f"a less-detailed update overwrote it. Latest text: {latest!r}"
+    )
 
 
 @then('the Steam message in chat {chat_id:d} is edited to contain "{expected}"')


### PR DESCRIPTION
## Summary
This PR fixes a bug where less-detailed Steam presence updates (e.g., "playing CS2" with no map/score info) could overwrite more-detailed messages (e.g., "playing CS2 with score 16-14 on Inferno") for the same gaming session. The fix ensures that detailed information is preserved unless the actual game, map, or status has changed.

## Key Changes

- **SteamService.ts**: Fixed the game change detection logic to compare `gameId` values as strings. The live `gameId` from the steam-user library is a string (e.g., "730"), while the stored value is reconstructed from the database. A strict type-sensitive comparison would always report a false change, disabling the less-detailed-update guard. Now both values are normalized to strings before comparison.

- **steam_steps.py**: Updated test fixtures to use `"gameid": "730"` (string) instead of `gameid: 730` (number) to match the actual behavior of the steam-user library. Added a new test step `step_steam_playing_no_details()` to simulate bare presence updates without map/score details.

- **steam_game_updates.feature**: Added a new acceptance test scenario that verifies a less-detailed update does not overwrite a more-detailed one. The test confirms that when a user is playing with score information, a subsequent bare "playing CS2" update does not remove the score from the displayed message.

## Notable Implementation Details

- The fix uses `String(value ?? '')` to safely normalize both the incoming and stored `gameId` values, handling potential null/undefined cases.
- The less-detailed-update guard only prevents overwrites when the game, map, or meaningful status hasn't actually changed—legitimate updates are still applied.
- Test coverage ensures the fix works end-to-end from Steam API through to the chat message display.

https://claude.ai/code/session_01FP88hCFM26YXscBJZxftAj