### PR TITLE
Reduce match idle timeout from 30 to 10 minutes

### DIFF
--- a/SteamService.ts
+++ b/SteamService.ts
@@ -12,7 +12,7 @@ import { saveSteamFile, readSteamFile } from './dao/Database.js';
 
 // A finished match with no further score progress is recorded once it has been idle
 // (CS2 not running, score unchanged) for this long. Overridable for tests.
-const MATCH_IDLE_MS = Number(process.env.MATCH_IDLE_MS) || 30 * 60 * 1000;
+const MATCH_IDLE_MS = Number(process.env.MATCH_IDLE_MS) || 10 * 60 * 1000;
 
 // How often the idle-match sweep runs. Overridable for tests.
 const MATCH_SWEEP_MS = Number(process.env.MATCH_SWEEP_MS) || 60 * 1000;


### PR DESCRIPTION
## Summary
Reduced the `MATCH_IDLE_MS` constant from 30 minutes to 10 minutes, which controls how long a finished match must remain idle (CS2 not running, score unchanged) before being recorded.

## Changes
- Updated `MATCH_IDLE_MS` default value from `30 * 60 * 1000` (30 minutes) to `10 * 60 * 1000` (10 minutes)
- This timeout is still overridable via the `MATCH_IDLE_MS` environment variable for testing and deployment flexibility

## Details
This change makes the system record finished matches more quickly after they become idle, reducing the latency between match completion and data persistence. The environment variable override remains in place, allowing for custom timeout values when needed.

https://claude.ai/code/session_017opaZ6DqWbBX7dXszZxoJ4