### PR TITLE
Clear stored game-update info when closing a Steam session

### DIFF
--- a/SteamService.ts
+++ b/SteamService.ts
@@ -773,8 +773,11 @@ class SteamService {
                 parse_mode: 'Markdown'
             });
 
-            // Update DAO with new text but keep old info
-            await this.gameUpdateDao.updateGameUpdateText(chatId, tgUserId, newText, lastUpdate.info);
+            // Update DAO with the red text, but drop the now-stale detail. A closed session
+            // has no live map/score left to protect, so the next launch — often a bare
+            // "playing" update before rich presence arrives — must not be suppressed by the
+            // less-detailed-update guard in publishUpdate().
+            await this.gameUpdateDao.updateGameUpdateText(chatId, tgUserId, newText, {});
 
         } catch (err: any) {
             if (err.message && err.message.includes('message is not modified')) {

--- a/acceptance/features/steam_game_updates.feature
+++ b/acceptance/features/steam_game_updates.feature
@@ -25,6 +25,20 @@ Feature: Steam game-presence updates
     And Steam reports user "76561198000000030" playing CS2 with no details
     Then the latest Steam message in chat 2003 still contains "Score:"
 
+  Scenario: a bare relaunch after a closed session goes back to green
+    Given a chat with id 2004
+    And a user with id 5904 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000040"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000040"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000040" playing CS2 with score "16-14" on map "Inferno"
+    Then chat 2004 receives a Steam message containing "Score:"
+    When Steam reports user "76561198000000040" stopped playing
+    Then the Steam message in chat 2004 is edited to contain "🔴"
+    When a moment passes
+    And Steam reports user "76561198000000040" playing CS2 with no details
+    Then the latest Steam message in chat 2004 still contains "🟢"
+
   Scenario: a chat that disabled updates receives nothing
     Given a chat with id 2002
     And a user with id 5902 and first name "Tester"


### PR DESCRIPTION
## Context

Follow-up to #36. The Codex review on that PR flagged a real regression that the gameId string-comparison fix exposed — confirmed by reading the code and reproduced with an acceptance test.

`maybeCloseSession()` flips the message to the red "stopped" state but kept the old detailed `info` (map/score) and a still-recent timestamp. With the now-correct `gameId` comparison, a bare CS2 relaunch within 6 hours (`gameid: "730"`, before rich presence arrives — the normal warm-up case) makes `gameChanged` false, so the less-detailed-update guard in `publishUpdate()` sees the kept score/map as lost detail and returns early — leaving the message stuck on 🔴 instead of flipping back to 🟢.

Before #36 this never surfaced because `gameChanged` was permanently true (`"730" !== 730`), so the guard was always skipped on relaunch.

## Fix

A closed session has no live detail left to protect, so drop the stored `info` on close. The next launch — even a bare one — then wins, while the original specificity guard still holds *within* a live session.

`GameUpdate.info` is only used for the `publishUpdate` diff; game history is tracked separately via `GameHistoryDAO`, so clearing it here is safe.

## Test

Adds an acceptance scenario *"a bare relaunch after a closed session goes back to green"*: play with a score → stop (🔴) → bare relaunch must put the message back to 🟢. It fails on the pre-fix code (message stuck on 🔴 with the old score) and passes after the fix.

Verified end-to-end via the Docker acceptance suite: **15 features / 47 scenarios / 286 steps, all green**, rebased on latest master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP88hCFM26YXscBJZxftAj)_