### PR TITLE
Tag full rotation on schedules, drop default RSVP category, rename Maybe button

### DIFF
--- a/acceptance/features/environment.py
+++ b/acceptance/features/environment.py
@@ -58,3 +58,6 @@ def before_scenario(context: Context, scenario: Scenario) -> None:
     context.chat_id = 1001
     context.user = {"id": 5001, "first_name": "Tester", "username": "tester"}
     context.last_reply = None
+    # Message id captured by the "the RSVP message is remembered" step, so later button
+    # taps can target a specific message even after newer messages arrive.
+    context.rsvp_message_id = None

--- a/acceptance/features/rsvp.feature
+++ b/acceptance/features/rsvp.feature
@@ -1,0 +1,63 @@
+Feature: RSVP buttons on schedules and rollcalls
+  Schedule confirmations and rollcalls carry inline RSVP buttons. The whole rotation is
+  tagged up front, players start uncategorised, and they move between the 🙋‍♂️/🤷‍♂️/🙅‍♂️
+  lists as they tap. Each scenario uses a distinct chat so the per-chat state stays isolated.
+
+  Scenario: a schedule tags the whole rotation but pre-categorises nobody
+    Given a chat with id 6001
+    And a user with id 6101 and first name "Captain"
+    When the user sends "/rollcall_add_player Alice" mentioning user 777 as "Alice"
+    Then the bot replies "Added 1 players to rollcall."
+    When the user sends "/schedule 3 hours"
+    Then the bot reply starts with "Rollcall scheduled for"
+    And the bot reply contains "tg://user?id=777"
+    And the bot reply contains "🙋‍♂️ Captain"
+    And the bot reply does not contain "🤷‍♂️"
+    And the bot reply offers a "I'm in" button
+    And the bot reply offers a "Maybe" button
+    And the bot reply offers a "No" button
+
+  Scenario: tapping moves a player between the RSVP lists
+    Given a chat with id 6002
+    And a user with id 6102 and first name "Captain"
+    When the user sends "/rollcall_add_player Alice" mentioning user 777 as "Alice"
+    Then the bot replies "Added 1 players to rollcall."
+    When the user sends "/schedule 3 hours"
+    Then the bot reply starts with "Rollcall scheduled for"
+    When the RSVP message is remembered
+    When user 777 named "Alice" taps maybe
+    Then the bot reply contains "🤷‍♂️ Alice"
+    When user 777 named "Alice" taps no
+    Then the bot reply contains "🙅‍♂️ Alice"
+    And the bot reply does not contain "🤷‍♂️"
+
+  Scenario: a rollcall offers the Joining / Maybe/Later / No buttons and seeds the initiator
+    Given a chat with id 6003
+    And a user with id 6103 and first name "Captain"
+    When the user sends "/rollcall"
+    Then the bot reply offers a "Joining" button
+    And the bot reply offers a "Maybe/Later" button
+    And the bot reply offers a "No" button
+    And the bot reply contains "🙋‍♂️ Captain"
+
+  Scenario: tapping a cancelled schedule's message reports an expired RSVP
+    Given a chat with id 6004
+    And a user with id 6104 and first name "Captain"
+    When the user sends "/schedule 3 hours"
+    Then the bot reply starts with "Rollcall scheduled for"
+    When the RSVP message is remembered
+    When the user sends "/cancel"
+    Then the bot replies "Scheduled rollcall cancelled."
+    When user 777 named "Alice" taps yes
+    Then the tap is answered with "This RSVP has expired."
+
+  Scenario: rescheduling retires the previous RSVP list
+    Given a chat with id 6005
+    And a user with id 6105 and first name "Captain"
+    When the user sends "/schedule 3 hours"
+    Then the bot reply starts with "Rollcall scheduled for"
+    When the RSVP message is remembered
+    When the user sends "/schedule 4 hours"
+    Then the bot reply starts with "Rollcall scheduled for"
+    When user 777 named "Alice" taps yes
+    Then the tap is answered with "This RSVP has expired."

--- a/acceptance/features/steps/helpers.py
+++ b/acceptance/features/steps/helpers.py
@@ -3,6 +3,7 @@
 Everything that talks to the mock Telegram server, the Steam control server or
 the MariaDB backend lives here so the step files stay declarative.
 """
+import json
 import os
 import time
 from typing import Any, Dict, List, Optional
@@ -132,6 +133,72 @@ def inject_message(
     )
     resp.raise_for_status()
     return resp.json()
+
+
+def inject_callback(
+    data: str, chat_id: int, user: Dict[str, Any], message_id: int
+) -> Dict[str, Any]:
+    """Queue a callback_query update, simulating a user tapping an inline button."""
+    update: Dict[str, Any] = {
+        "callback_query": {
+            "id": str(int(time.time() * 1000) % 1000000),
+            "from": {
+                "id": int(user["id"]),
+                "is_bot": False,
+                "first_name": user.get("first_name", "Tester"),
+                "username": user.get("username", "tester"),
+            },
+            "message": {
+                "message_id": int(message_id),
+                "date": int(time.time()),
+                "chat": {"id": int(chat_id), "type": "group"},
+            },
+            "data": data,
+        }
+    }
+    resp = requests.post(f"{TELEGRAM_MOCK_URL}/test/inject", json=update, timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def reply_markup(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the inline keyboard markup of a recorded outbox message, parsed to a dict.
+
+    node-telegram-bot-api may send reply_markup either as a JSON string (form-encoded)
+    or as a nested object (JSON body); handle both.
+    """
+    markup: Any = message.get("params", {}).get("reply_markup")
+    if isinstance(markup, str):
+        return json.loads(markup)
+    return markup or {}
+
+
+def button_labels(message: Dict[str, Any]) -> List[str]:
+    markup: Dict[str, Any] = reply_markup(message)
+    return [
+        button.get("text")
+        for row in markup.get("inline_keyboard", [])
+        for button in row
+    ]
+
+
+def get_callback_answers() -> List[Dict[str, Any]]:
+    resp = requests.get(f"{TELEGRAM_MOCK_URL}/test/callback-answers", timeout=5)
+    resp.raise_for_status()
+    return resp.json()["answers"]
+
+
+def wait_for_callback_answer(
+    baseline_count: int, timeout: float = REPLY_TIMEOUT
+) -> List[Dict[str, Any]]:
+    """Wait until a new answerCallbackQuery is recorded; return the new tail."""
+    deadline: float = time.time() + timeout
+    while time.time() < deadline:
+        answers: List[Dict[str, Any]] = get_callback_answers()
+        if len(answers) > baseline_count:
+            return answers[baseline_count:]
+        time.sleep(POLL_INTERVAL)
+    return get_callback_answers()[baseline_count:]
 
 
 def get_outbox(chat_id: Optional[int] = None) -> List[Dict[str, Any]]:

--- a/acceptance/features/steps/telegram_steps.py
+++ b/acceptance/features/steps/telegram_steps.py
@@ -4,7 +4,7 @@ These use behave's regex matcher (which anchors patterns at both ends) so the
 generic "the user sends ..." step does not greedily swallow the more specific
 mention variants.
 """
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from behave import given, when, then, use_step_matcher
 from behave.runner import Context
@@ -81,11 +81,16 @@ def _new_messages(context: Context) -> List[Dict[str, Any]]:
     return helpers.wait_for_new_message(context.cmd_chat, context.cmd_baseline)
 
 
-def _latest_reply(context: Context) -> str:
+def _latest_message(context: Context) -> Dict[str, Any]:
     new: List[Dict[str, Any]] = _new_messages(context)
     assert new, "Expected the bot to reply, but the outbox stayed empty"
+    context.last_message = new[-1]
     context.last_reply = new[-1]["text"]
-    return context.last_reply
+    return new[-1]
+
+
+def _latest_reply(context: Context) -> str:
+    return _latest_message(context)["text"]
 
 
 @then('the bot replies "(?P<expected>[^"]*)"')
@@ -120,3 +125,51 @@ def step_reply_first_line_one_of(context: Context) -> None:
 def step_no_reply(context: Context) -> None:
     new: List[Dict[str, Any]] = helpers.expect_no_new_message(context.cmd_chat, context.cmd_baseline)
     assert not new, f"Expected no reply, but the bot sent: {[m['text'] for m in new]}"
+
+
+@then('the bot reply does not contain "(?P<unexpected>[^"]*)"')
+def step_reply_not_contains(context: Context, unexpected: str) -> None:
+    reply: str = _latest_reply(context)
+    assert unexpected not in reply, \
+        f"Expected reply not to contain {unexpected!r}, got {reply!r}"
+
+
+@then('the bot reply offers a "(?P<label>[^"]*)" button')
+def step_reply_offers_button(context: Context, label: str) -> None:
+    message: Dict[str, Any] = _latest_message(context)
+    labels: List[Optional[str]] = helpers.button_labels(message)
+    assert label in labels, f"Expected a {label!r} button, got {labels}"
+
+
+# ---------------------------------------------------------------------------
+# RSVP inline-button taps (callback queries)
+# ---------------------------------------------------------------------------
+
+@when('the RSVP message is remembered')
+def step_remember_rsvp_message(context: Context) -> None:
+    outbox: List[Dict[str, Any]] = helpers.get_outbox(context.chat_id)
+    assert outbox, "No bot message exists to remember"
+    context.rsvp_message_id = outbox[-1]["message_id"]
+
+
+@when('user (?P<user_id>\\d+) named "(?P<name>[^"]*)" taps (?P<choice>yes|maybe|no)')
+def step_user_taps(context: Context, user_id: str, name: str, choice: str) -> None:
+    # Tap the explicitly remembered message if there is one, otherwise the most recent.
+    message_id: Optional[int] = getattr(context, "rsvp_message_id", None)
+    if message_id is None:
+        outbox: List[Dict[str, Any]] = helpers.get_outbox(context.chat_id)
+        assert outbox, "No bot message exists to tap on"
+        message_id = outbox[-1]["message_id"]
+
+    context.cmd_chat = context.chat_id
+    context.cmd_baseline = len(helpers.get_outbox(context.chat_id))
+    context.cb_baseline = len(helpers.get_callback_answers())
+    user: Dict[str, Any] = {"id": int(user_id), "first_name": name, "username": name.lower()}
+    helpers.inject_callback(f"rsvp:{choice}", context.chat_id, user, message_id)
+
+
+@then('the tap is answered with "(?P<expected>[^"]*)"')
+def step_tap_answered_with(context: Context, expected: str) -> None:
+    answers: List[Dict[str, Any]] = helpers.wait_for_callback_answer(context.cb_baseline)
+    texts: List[Optional[str]] = [a.get("text") for a in answers]
+    assert expected in texts, f"Expected a callback answer {expected!r}, got {texts}"

--- a/acceptance/telegram_mock/server.py
+++ b/acceptance/telegram_mock/server.py
@@ -33,15 +33,20 @@ _next_update_id: int = 1
 _outbox: List[Dict[str, Any]] = []
 _next_message_id: int = 1000
 
+# Ordered record of every answerCallbackQuery the bot made, so behave can assert on
+# the feedback shown for a button tap (e.g. an expired RSVP).
+_callback_answers: List[Dict[str, Any]] = []
+
 
 def _reset() -> None:
     # NOTE: _next_update_id is deliberately NOT reset. The bot's long-poll
     # offset increases monotonically for the life of its process, so update_ids
     # must keep climbing across scenario resets — otherwise post-reset updates
     # fall below the bot's offset and getUpdates never delivers them.
-    global _updates, _outbox
+    global _updates, _outbox, _callback_answers
     _updates = []
     _outbox = []
+    _callback_answers = []
 
 
 # ---------------------------------------------------------------------------
@@ -82,6 +87,7 @@ def bot_api(token: str, method: str) -> Response:
             _outbox.append({
                 "method": "sendMessage",
                 "chat_id": str(chat_id) if chat_id is not None else None,
+                "message_id": message_id,
                 "text": text,
                 "params": params,
             })
@@ -115,6 +121,14 @@ def bot_api(token: str, method: str) -> Response:
                 "text": text,
             },
         })
+
+    if method == "answerCallbackQuery":
+        with _lock:
+            _callback_answers.append({
+                "callback_query_id": params.get("callback_query_id"),
+                "text": params.get("text"),
+            })
+        return jsonify({"ok": True, "result": True})
 
     if method == "getMe":
         return jsonify({
@@ -152,7 +166,7 @@ def inject() -> Response:
     global _next_update_id
     body = request.get_json(force=True) or {}
     with _lock:
-        if "message" in body or "edited_message" in body:
+        if any(key in body for key in ("message", "edited_message", "callback_query")):
             update = dict(body)
         else:
             update = {"message": body}
@@ -172,6 +186,12 @@ def outbox() -> Response:
         else:
             result = list(_outbox)
     return jsonify({"ok": True, "outbox": result})
+
+
+@app.route("/test/callback-answers", methods=["GET"])
+def callback_answers() -> Response:
+    with _lock:
+        return jsonify({"ok": True, "answers": list(_callback_answers)})
 
 
 @app.route("/test/reset", methods=["POST"])

--- a/command/schedule.ts
+++ b/command/schedule.ts
@@ -72,8 +72,11 @@ export default (bot: TelegramBot, msg: ExtendedMessage): void => {
                         entries[msg.from.id] = entryFromUser(msg.from, 'yes');
                     }
 
-                    const baseText: string = `Rollcall scheduled for ${escapeMarkdown(timeString)}`;
-                    const { groups } = resolve(rotation, entries);
+                    const { groups, mentions } = resolve(rotation, entries);
+                    // Like a rollcall, the schedule tags the whole rotation up front. The
+                    // mention line is baked in here so it records who was pinged when scheduled.
+                    const heading: string = `Rollcall scheduled for ${escapeMarkdown(timeString)}`;
+                    const baseText: string = mentions.length ? `${heading}\n${mentions.join(' ')}` : heading;
 
                     return bot.sendMessage(chat_id, renderMessage(baseText, groups), {
                         reply_parameters: { message_id: msg.message_id },

--- a/rsvp.ts
+++ b/rsvp.ts
@@ -6,7 +6,7 @@ export type RsvpKeyboardKind = 'schedule' | 'rollcall';
 
 const LABELS: Record<RsvpKeyboardKind, Record<Rsvp, string>> = {
     schedule: { yes: "I'm in", maybe: 'Maybe', no: 'No' },
-    rollcall: { yes: 'Joining', maybe: 'Maybe later', no: 'No' }
+    rollcall: { yes: 'Joining', maybe: 'Maybe/Later', no: 'No' }
 };
 
 const RSVP_EMOJI: Record<Rsvp, string> = {
@@ -52,20 +52,22 @@ const parseMention = (mention: string): ParsedMention => {
 const displayName = (name: string): string => escapeMarkdown(name).replace('@', '@​');
 
 interface ResolvedPerson {
-    rsvp: Rsvp;
+    // Undefined until the person makes a selection: players are uncategorised by default.
+    rsvp?: Rsvp;
     name: string;
     // The original rotation mention string, if this person is a rotation player.
     mention?: string;
 }
 
 export interface RsvpGroups {
-    groups: Record<Rsvp, string[]>; // display names per rsvp value
+    groups: Record<Rsvp, string[]>; // display names per rsvp value (only those who chose)
     mentions: string[];             // rotation mention strings whose rsvp != 'no'
 }
 
 // Combine the live rotation roster with the explicit entries on the RSVP list.
-// Rotation players default to 'maybe'; explicit entries (incl. the seeded initiator)
-// override, and non-rotation tappers are appended as extra people.
+// Players are uncategorised until they tap a button; explicit entries (incl. the seeded
+// initiator) place them into yes/maybe/no, and non-rotation tappers are appended as extra
+// people. Every rotation player is still tagged in the mention line unless they opted out.
 const resolve = (rotation: string[], entries: Record<string, RsvpEntry>): RsvpGroups => {
     const people: ResolvedPerson[] = [];
     const byId: Map<number, ResolvedPerson> = new Map();
@@ -73,7 +75,7 @@ const resolve = (rotation: string[], entries: Record<string, RsvpEntry>): RsvpGr
 
     rotation.forEach(mention => {
         const parsed = parseMention(mention);
-        const person: ResolvedPerson = { rsvp: 'maybe', name: parsed.display, mention };
+        const person: ResolvedPerson = { name: parsed.display, mention };
         people.push(person);
         if (parsed.id !== undefined) {
             byId.set(parsed.id, person);
@@ -98,7 +100,11 @@ const resolve = (rotation: string[], entries: Record<string, RsvpEntry>): RsvpGr
     const groups: Record<Rsvp, string[]> = { yes: [], maybe: [], no: [] };
     const mentions: string[] = [];
     people.forEach(person => {
-        groups[person.rsvp].push(displayName(person.name));
+        // Only people who have actually made a selection appear in the lists.
+        if (person.rsvp) {
+            groups[person.rsvp].push(displayName(person.name));
+        }
+        // Tag every rotation player except those who explicitly opted out.
         if (person.mention && person.rsvp !== 'no') {
             mentions.push(person.mention);
         }

--- a/rsvp.ts
+++ b/rsvp.ts
@@ -51,6 +51,18 @@ const parseMention = (mention: string): ParsedMention => {
 // (zero-width space breaks the @mention), matching command/admin/rollcall_get_players.ts.
 const displayName = (name: string): string => escapeMarkdown(name).replace('@', '@​');
 
+// Build a Markdown-safe pingable mention for the tag line. A rotation entry is stored
+// either as a `[name](tg://user?id=ID)` text-mention link or a plain `@username`. The line
+// is baked into a `parse_mode: 'Markdown'` message, so escape the visible text — otherwise a
+// name with a Markdown metacharacter (e.g. `Foo_Bar`) makes Telegram reject the message.
+const mentionMarkdown = (mention: string): string => {
+    const match: RegExpMatchArray | null = mention.match(/^\[(.*)\]\(tg:\/\/user\?id=(\d+)\)$/);
+    if (match) {
+        return `[${escapeMarkdown(match[1])}](tg://user?id=${match[2]})`;
+    }
+    return escapeMarkdown(mention);
+};
+
 interface ResolvedPerson {
     // Undefined until the person makes a selection: players are uncategorised by default.
     rsvp?: Rsvp;
@@ -106,7 +118,7 @@ const resolve = (rotation: string[], entries: Record<string, RsvpEntry>): RsvpGr
         }
         // Tag every rotation player except those who explicitly opted out.
         if (person.mention && person.rsvp !== 'no') {
-            mentions.push(person.mention);
+            mentions.push(mentionMarkdown(person.mention));
         }
     });
 


### PR DESCRIPTION
## What

Follow-up tweaks to the RSVP feature on `/schedule` and `/rollcall`:

1. **Schedule messages now tag the whole rollcall rotation up front**, the same way rollcall messages do. The mention line is baked into the message at send time (so it records who was pinged when the rollcall was scheduled).
2. **Players no longer default into "maybe".** Previously every rotation player started in the 🤷‍♂️ list, which made tapping "Maybe" usually a no-op. Now players appear in the 🙋‍♂️/🤷‍♂️/🙅‍♂️ lists only once they actually make a selection.
3. **The mention line still tags everyone except "No".** Players in yes/maybe — and players who never responded — are all tagged when a schedule fires; only those who explicitly tapped "No" are dropped. This keeps the schedule→rollcall hand-off pinging everyone who hasn't opted out.
4. **Renamed the rollcall "Maybe later" button to "Maybe/Later".**

## How

- `rsvp.ts`: `resolve()` no longer assigns a default `'maybe'` to rotation players — `ResolvedPerson.rsvp` is now optional and only set by an explicit entry. People are added to a list only when categorised; the mention line keeps tagging any rotation player whose effective RSVP isn't `'no'`. Updated the rollcall `Maybe/Later` label.
- `command/schedule.ts`: appends the rotation mention line (from `resolve()`) under the "Rollcall scheduled for …" heading, baked into the stored base text.

## Notes

- The schedule confirmation still **starts with** "Rollcall scheduled for …", and the rollcall message's first line is still a quote, so the existing acceptance scenarios are unaffected.
- Verified with `npm run build` and a logic check of `resolve()` against fresh/post-tap states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Msmji7u85wjWjrxpoSfFYK)_