### PR TITLE
Group end-of-game notifications into one message per match

### DIFF
--- a/SteamService.ts
+++ b/SteamService.ts
@@ -728,25 +728,24 @@ class SteamService {
         const parsed = this.parseRawScore(score);
         if (!parsed) {
             return null;
-        }
-        if (parsed.a > parsed.b) {
+        } else if (parsed.a > parsed.b) {
             return 'win';
-        }
-        if (parsed.a < parsed.b) {
+        } else if (parsed.a < parsed.b) {
             return 'loss';
+        } else {
+            return 'tie';
         }
-        return 'tie';
     }
 
     // Join names into "A", "A and B", or "A, B and C". Order is irrelevant.
     private formatNameList(names: string[]): string {
         if (names.length === 0) {
             return 'Someone';
-        }
-        if (names.length === 1) {
+        } else if (names.length === 1) {
             return names[0];
+        } else {
+            return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
         }
-        return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
     }
 
     private endOfGameText(names: string[], result: 'win' | 'loss' | 'tie', map?: string, mode?: string, score?: string): string {

--- a/SteamService.ts
+++ b/SteamService.ts
@@ -4,7 +4,7 @@ import TelegramBot from 'node-telegram-bot-api';
 import UserDAO, { UserSettings } from './dao/UserDAO.js';
 import ChatDAO, { ChatSettings } from './dao/ChatDAO.js';
 import GameUpdateDAO, { GameUpdate } from './dao/GameUpdateDAO.js';
-import GameHistoryDAO, { CurrentMatch, GameHistoryEntry, GameHistoryCoPlayer } from './dao/GameHistoryDAO.js';
+import GameHistoryDAO, { CurrentMatch, GameHistoryEntry, GameHistoryCoPlayer, SiblingMatch } from './dao/GameHistoryDAO.js';
 import RollcallPlayerDAO from './dao/RollcallPlayerDAO.js';
 import { escapeMarkdown } from './utils.js';
 import { parseMention } from './rsvp.js';
@@ -712,7 +712,7 @@ class SteamService {
                     // Serialise announcing per chat so two players finalising the same match
                     // concurrently can't each create a separate message.
                     await this.withLock(`eog_${chatId}`, () =>
-                        this.announceFinishedMatch(chatId, historyId, match));
+                        this.announceFinishedMatch(chatId, historyId, match, playerName));
                 }
             }
         } catch (err) {
@@ -753,53 +753,78 @@ class SteamService {
     // Announce a finished match as a single per-match message that names every participating
     // player. Players in the same chat finish the same match at different (often widely spaced)
     // times, so the first finaliser posts the message and each later one edits it to add names.
-    // Same-match siblings are the recently-finalised game_history rows in this chat with the same
-    // map + mode, the same win/loss/tie result, and a round total within RESET_TOLERANCE.
-    private async announceFinishedMatch(chatId: number, historyId: number, match: CurrentMatch): Promise<void> {
+    //
+    // Same-match candidates are the recently-finalised game_history rows in this chat with the same
+    // map + mode, the same win/loss/tie result, and a round total within RESET_TOLERANCE. Signature
+    // alone can't distinguish "another player in the same match" from "the same player in a *later*
+    // match on the same map", so we only join an existing announcement that this player does not
+    // already OWN a row in — a player is in any given match instance exactly once, so an existing
+    // group already owned by them is a different match and must get its own message.
+    private async announceFinishedMatch(chatId: number, historyId: number, match: CurrentMatch, playerName: string): Promise<void> {
         const result = this.matchResult(match.max_score);
         if (!result) return;
         const total = this.parseRawScore(match.max_score)?.total;
 
         const since = new Date(Date.now() - EOG_GROUP_WINDOW_MS);
         const candidates = await this.gameHistoryDao.getRecentSiblingMatches(chatId, match.map, match.mode, since);
-        const siblings = candidates.filter(c => {
+        const sameSig = candidates.filter(c => {
+            if (c.id === historyId) return false;
             if (this.matchResult(c.score) !== result) return false;
             const t = this.parseRawScore(c.score)?.total;
             if (total != null && t != null && Math.abs(total - t) > RESET_TOLERANCE) return false;
             return true;
         });
 
-        // Build the participant set: each sibling's owner (display name resolved and stored at
-        // finalise) plus its co-players, deduped by user id.
-        const namesByUser = new Map<number, string>();
-        for (const sib of siblings) {
-            if (!namesByUser.has(sib.user_id)) {
-                namesByUser.set(sib.user_id, sib.player_name || String(sib.user_id));
+        // Group the existing announcements (rows sharing a message_id) and pick the most recent one
+        // this player doesn't already own a row in.
+        const groups = new Map<number, { ownerIds: Set<number>; rows: SiblingMatch[]; maxId: number }>();
+        for (const row of sameSig) {
+            if (row.message_id == null) continue;
+            let g = groups.get(row.message_id);
+            if (!g) {
+                g = { ownerIds: new Set<number>(), rows: [], maxId: 0 };
+                groups.set(row.message_id, g);
             }
-            for (const co of sib.co_players) {
-                if (!namesByUser.has(co.tg_user_id)) {
-                    namesByUser.set(co.tg_user_id, co.name);
-                }
+            g.ownerIds.add(row.user_id);
+            g.rows.push(row);
+            g.maxId = Math.max(g.maxId, row.id);
+        }
+        let target: { messageId: number; rows: SiblingMatch[]; maxId: number } | null = null;
+        for (const [messageId, g] of groups) {
+            if (g.ownerIds.has(match.user_id)) continue; // a previous match of this player
+            if (!target || g.maxId > target.maxId) target = { messageId, rows: g.rows, maxId: g.maxId };
+        }
+
+        // Participants: this player (+ their co-players) unioned with the chosen group's rows. For a
+        // fresh announcement only this player's match contributes — never the earlier match's rows.
+        const namesByUser = new Map<number, string>();
+        namesByUser.set(match.user_id, playerName || String(match.user_id));
+        for (const co of match.co_players || []) {
+            if (!namesByUser.has(co.tg_user_id)) namesByUser.set(co.tg_user_id, co.name);
+        }
+        for (const row of target?.rows || []) {
+            if (!namesByUser.has(row.user_id)) namesByUser.set(row.user_id, row.player_name || String(row.user_id));
+            for (const co of row.co_players) {
+                if (!namesByUser.has(co.tg_user_id)) namesByUser.set(co.tg_user_id, co.name);
             }
         }
         const names = Array.from(namesByUser.values());
         const text = this.endOfGameText(names, result, match.map, match.mode, match.max_score);
 
-        const existingMessageId = siblings.map(s => s.message_id).find(id => id != null) ?? null;
-        if (existingMessageId != null) {
+        if (target) {
             try {
                 await this.bot.editMessageText(text, {
                     chat_id: chatId,
-                    message_id: existingMessageId,
+                    message_id: target.messageId,
                     parse_mode: 'Markdown'
                 });
             } catch (err: any) {
                 if (!(err.message && err.message.includes('message is not modified'))) {
-                    console.error(`Failed to edit end-of-game message ${existingMessageId} in chat ${chatId}:`, err);
+                    console.error(`Failed to edit end-of-game message ${target.messageId} in chat ${chatId}:`, err);
                 }
             }
             // Carry the id onto our own row so any later sibling lookup finds it.
-            await this.gameHistoryDao.setGameHistoryMessageId(historyId, existingMessageId);
+            await this.gameHistoryDao.setGameHistoryMessageId(historyId, target.messageId);
             return;
         }
 

--- a/SteamService.ts
+++ b/SteamService.ts
@@ -726,16 +726,26 @@ class SteamService {
     // win/loss/tie classification of a raw "16-14" score (player-opponent), or null if unparseable.
     private matchResult(score?: string): 'win' | 'loss' | 'tie' | null {
         const parsed = this.parseRawScore(score);
-        if (!parsed) return null;
-        if (parsed.a > parsed.b) return 'win';
-        if (parsed.a < parsed.b) return 'loss';
+        if (!parsed) {
+            return null;
+        }
+        if (parsed.a > parsed.b) {
+            return 'win';
+        }
+        if (parsed.a < parsed.b) {
+            return 'loss';
+        }
         return 'tie';
     }
 
     // Join names into "A", "A and B", or "A, B and C". Order is irrelevant.
     private formatNameList(names: string[]): string {
-        if (names.length === 0) return 'Someone';
-        if (names.length === 1) return names[0];
+        if (names.length === 0) {
+            return 'Someone';
+        }
+        if (names.length === 1) {
+            return names[0];
+        }
         return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
     }
 
@@ -744,9 +754,15 @@ class SteamService {
         const verb = result === 'win' ? 'won' : result === 'loss' ? 'lost' : 'tied';
         const nameList = this.formatNameList(names.map(n => escapeMarkdown(n)));
         let text = `${emoji} *${nameList}* ${verb} a game`;
-        if (map) text += ` on ${escapeMarkdown(map)}`;
-        if (mode) text += ` (${escapeMarkdown(mode)})`;
-        if (score) text += `: ${this.formatScore(score)}`;
+        if (map) {
+            text += ` on ${escapeMarkdown(map)}`;
+        }
+        if (mode) {
+            text += ` (${escapeMarkdown(mode)})`;
+        }
+        if (score) {
+            text += `: ${this.formatScore(score)}`;
+        }
         return text;
     }
 
@@ -762,16 +778,24 @@ class SteamService {
     // group already owned by them is a different match and must get its own message.
     private async announceFinishedMatch(chatId: number, historyId: number, match: CurrentMatch, playerName: string): Promise<void> {
         const result = this.matchResult(match.max_score);
-        if (!result) return;
+        if (!result) {
+            return;
+        }
         const total = this.parseRawScore(match.max_score)?.total;
 
         const since = new Date(Date.now() - EOG_GROUP_WINDOW_MS);
         const candidates = await this.gameHistoryDao.getRecentSiblingMatches(chatId, match.map, match.mode, since);
         const sameSig = candidates.filter(c => {
-            if (c.id === historyId) return false;
-            if (this.matchResult(c.score) !== result) return false;
+            if (c.id === historyId) {
+                return false;
+            }
+            if (this.matchResult(c.score) !== result) {
+                return false;
+            }
             const t = this.parseRawScore(c.score)?.total;
-            if (total != null && t != null && Math.abs(total - t) > RESET_TOLERANCE) return false;
+            if (total != null && t != null && Math.abs(total - t) > RESET_TOLERANCE) {
+                return false;
+            }
             return true;
         });
 
@@ -779,7 +803,9 @@ class SteamService {
         // this player doesn't already own a row in.
         const groups = new Map<number, { ownerIds: Set<number>; rows: SiblingMatch[]; maxId: number }>();
         for (const row of sameSig) {
-            if (row.message_id == null) continue;
+            if (row.message_id == null) {
+                continue;
+            }
             let g = groups.get(row.message_id);
             if (!g) {
                 g = { ownerIds: new Set<number>(), rows: [], maxId: 0 };
@@ -791,8 +817,12 @@ class SteamService {
         }
         let target: { messageId: number; rows: SiblingMatch[]; maxId: number } | null = null;
         for (const [messageId, g] of groups) {
-            if (g.ownerIds.has(match.user_id)) continue; // a previous match of this player
-            if (!target || g.maxId > target.maxId) target = { messageId, rows: g.rows, maxId: g.maxId };
+            if (g.ownerIds.has(match.user_id)) {
+                continue; // a previous match of this player
+            }
+            if (!target || g.maxId > target.maxId) {
+                target = { messageId, rows: g.rows, maxId: g.maxId };
+            }
         }
 
         // Participants: this player (+ their co-players) unioned with the chosen group's rows. For a
@@ -800,12 +830,18 @@ class SteamService {
         const namesByUser = new Map<number, string>();
         namesByUser.set(match.user_id, playerName || String(match.user_id));
         for (const co of match.co_players || []) {
-            if (!namesByUser.has(co.tg_user_id)) namesByUser.set(co.tg_user_id, co.name);
+            if (!namesByUser.has(co.tg_user_id)) {
+                namesByUser.set(co.tg_user_id, co.name);
+            }
         }
         for (const row of target?.rows || []) {
-            if (!namesByUser.has(row.user_id)) namesByUser.set(row.user_id, row.player_name || String(row.user_id));
+            if (!namesByUser.has(row.user_id)) {
+                namesByUser.set(row.user_id, row.player_name || String(row.user_id));
+            }
             for (const co of row.co_players) {
-                if (!namesByUser.has(co.tg_user_id)) namesByUser.set(co.tg_user_id, co.name);
+                if (!namesByUser.has(co.tg_user_id)) {
+                    namesByUser.set(co.tg_user_id, co.name);
+                }
             }
         }
         const names = Array.from(namesByUser.values());

--- a/SteamService.ts
+++ b/SteamService.ts
@@ -17,6 +17,11 @@ const MATCH_IDLE_MS = Number(process.env.MATCH_IDLE_MS) || 10 * 60 * 1000;
 // How often the idle-match sweep runs. Overridable for tests.
 const MATCH_SWEEP_MS = Number(process.env.MATCH_SWEEP_MS) || 60 * 1000;
 
+// How recently a match must have been announced for a later-finalising player of the same match
+// to be grouped into (and edit) that existing message rather than posting a fresh one. Players'
+// Steam presence — and thus finalisations — for one match can arrive minutes apart. Overridable.
+const EOG_GROUP_WINDOW_MS = Number(process.env.EOG_GROUP_WINDOW_MS) || 2 * 60 * 60 * 1000;
+
 // How far a freshly reported round-total may dip below the running match total before we
 // treat it as a brand new match rather than out-of-order update noise.
 const RESET_TOLERANCE = 2;
@@ -531,14 +536,19 @@ class SteamService {
         return { map, mode, total: this.parseRawScore(score)?.total };
     }
 
-    // Run fn with exclusive access to a (chat,Steam account)'s match buffer, chaining onto any
-    // in-flight operation for the same key so concurrent presence updates are applied in series.
-    private withMatchLock<T>(chatId: number, steamId: string, fn: () => Promise<T>): Promise<T> {
-        const key = `${chatId}_${steamId}`;
+    // Run fn with exclusive access to a named lock, chaining onto any in-flight operation for the
+    // same key so concurrent callers are serialised.
+    private withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
         const prev = this.matchLocks[key] || Promise.resolve();
         const run = prev.then(fn, fn);
         this.matchLocks[key] = run.then(() => undefined, () => undefined);
         return run;
+    }
+
+    // Run fn with exclusive access to a (chat,Steam account)'s match buffer, chaining onto any
+    // in-flight operation for the same key so concurrent presence updates are applied in series.
+    private withMatchLock<T>(chatId: number, steamId: string, fn: () => Promise<T>): Promise<T> {
+        return this.withLock(`${chatId}_${steamId}`, fn);
     }
 
     // Update the persisted "current match" buffer for a (chat, Steam account) from a presence
@@ -680,9 +690,14 @@ class SteamService {
         const tgUserId = match.user_id;
         try {
             if (match.max_score) {
+                // Resolve and store the owner's display name now so a later-finalising player of
+                // the same match can render this name into the shared announcement without having
+                // to re-resolve it.
+                const playerName = (await this.getTelegramDisplayName(chatId, tgUserId)) || match.player_name || String(tgUserId);
                 const entry: GameHistoryEntry = {
                     chat_id: chatId,
                     user_id: tgUserId,
+                    player_name: playerName,
                     mode: match.mode,
                     map: match.map,
                     score: match.max_score,
@@ -690,11 +705,14 @@ class SteamService {
                     started_at: match.started_at,
                     ended_at: new Date()
                 };
-                await this.gameHistoryDao.addGameHistoryEntry(entry);
+                const historyId = await this.gameHistoryDao.addGameHistoryEntry(entry);
 
                 const chatSettings: ChatSettings = await this.chatDao.getChatSettings(chatId);
                 if (chatSettings.steam_updates !== false) {
-                    await this.postEndOfGameNotification(chatId, tgUserId, match);
+                    // Serialise announcing per chat so two players finalising the same match
+                    // concurrently can't each create a separate message.
+                    await this.withLock(`eog_${chatId}`, () =>
+                        this.announceFinishedMatch(chatId, historyId, match));
                 }
             }
         } catch (err) {
@@ -705,13 +723,90 @@ class SteamService {
         }
     }
 
-    private async postEndOfGameNotification(chatId: number, tgUserId: number, match: CurrentMatch): Promise<void> {
-        const displayName = (await this.getTelegramDisplayName(chatId, tgUserId)) || match.player_name || 'Someone';
-        let text = `🏁 *${escapeMarkdown(displayName)}* finished a game`;
-        if (match.map) text += ` on ${escapeMarkdown(match.map)}`;
-        if (match.mode) text += ` (${escapeMarkdown(match.mode)})`;
-        if (match.max_score) text += `: ${escapeMarkdown(this.formatScore(match.max_score))} ${this.resultEmoji(match.max_score)}`;
-        await this.bot.sendMessage(chatId, text, { parse_mode: 'Markdown' });
+    // win/loss/tie classification of a raw "16-14" score (player-opponent), or null if unparseable.
+    private matchResult(score?: string): 'win' | 'loss' | 'tie' | null {
+        const parsed = this.parseRawScore(score);
+        if (!parsed) return null;
+        if (parsed.a > parsed.b) return 'win';
+        if (parsed.a < parsed.b) return 'loss';
+        return 'tie';
+    }
+
+    // Join names into "A", "A and B", or "A, B and C". Order is irrelevant.
+    private formatNameList(names: string[]): string {
+        if (names.length === 0) return 'Someone';
+        if (names.length === 1) return names[0];
+        return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+    }
+
+    private endOfGameText(names: string[], result: 'win' | 'loss' | 'tie', map?: string, mode?: string, score?: string): string {
+        const emoji = result === 'win' ? '🏆' : result === 'loss' ? '☠️' : '🤝';
+        const verb = result === 'win' ? 'won' : result === 'loss' ? 'lost' : 'tied';
+        const nameList = this.formatNameList(names.map(n => escapeMarkdown(n)));
+        let text = `${emoji} *${nameList}* ${verb} a game`;
+        if (map) text += ` on ${escapeMarkdown(map)}`;
+        if (mode) text += ` (${escapeMarkdown(mode)})`;
+        if (score) text += `: ${this.formatScore(score)}`;
+        return text;
+    }
+
+    // Announce a finished match as a single per-match message that names every participating
+    // player. Players in the same chat finish the same match at different (often widely spaced)
+    // times, so the first finaliser posts the message and each later one edits it to add names.
+    // Same-match siblings are the recently-finalised game_history rows in this chat with the same
+    // map + mode, the same win/loss/tie result, and a round total within RESET_TOLERANCE.
+    private async announceFinishedMatch(chatId: number, historyId: number, match: CurrentMatch): Promise<void> {
+        const result = this.matchResult(match.max_score);
+        if (!result) return;
+        const total = this.parseRawScore(match.max_score)?.total;
+
+        const since = new Date(Date.now() - EOG_GROUP_WINDOW_MS);
+        const candidates = await this.gameHistoryDao.getRecentSiblingMatches(chatId, match.map, match.mode, since);
+        const siblings = candidates.filter(c => {
+            if (this.matchResult(c.score) !== result) return false;
+            const t = this.parseRawScore(c.score)?.total;
+            if (total != null && t != null && Math.abs(total - t) > RESET_TOLERANCE) return false;
+            return true;
+        });
+
+        // Build the participant set: each sibling's owner (display name resolved and stored at
+        // finalise) plus its co-players, deduped by user id.
+        const namesByUser = new Map<number, string>();
+        for (const sib of siblings) {
+            if (!namesByUser.has(sib.user_id)) {
+                namesByUser.set(sib.user_id, sib.player_name || String(sib.user_id));
+            }
+            for (const co of sib.co_players) {
+                if (!namesByUser.has(co.tg_user_id)) {
+                    namesByUser.set(co.tg_user_id, co.name);
+                }
+            }
+        }
+        const names = Array.from(namesByUser.values());
+        const text = this.endOfGameText(names, result, match.map, match.mode, match.max_score);
+
+        const existingMessageId = siblings.map(s => s.message_id).find(id => id != null) ?? null;
+        if (existingMessageId != null) {
+            try {
+                await this.bot.editMessageText(text, {
+                    chat_id: chatId,
+                    message_id: existingMessageId,
+                    parse_mode: 'Markdown'
+                });
+            } catch (err: any) {
+                if (!(err.message && err.message.includes('message is not modified'))) {
+                    console.error(`Failed to edit end-of-game message ${existingMessageId} in chat ${chatId}:`, err);
+                }
+            }
+            // Carry the id onto our own row so any later sibling lookup finds it.
+            await this.gameHistoryDao.setGameHistoryMessageId(historyId, existingMessageId);
+            return;
+        }
+
+        const sent = await this.bot.sendMessage(chatId, text, { parse_mode: 'Markdown' });
+        if (sent && sent.message_id) {
+            await this.gameHistoryDao.setGameHistoryMessageId(historyId, sent.message_id);
+        }
     }
 
     // Finalise matches that have gone idle (CS2 not running, no score progress) past the window.

--- a/acceptance/features/game_history.feature
+++ b/acceptance/features/game_history.feature
@@ -151,7 +151,10 @@ Feature: CS2 game history
     And Steam reports user "76561198000000971" playing CS2 as "Bravo" with score "13-7" on map "Vertigo"
     And Steam reports user "76561198000000971" stopped playing
     Then chat 2110 eventually receives a new Steam message containing "won a game"
-    And the Steam message in chat 2110 is edited to contain "Alpha and Bravo"
+    # The second finaliser edits the first's message to add their name (order is irrelevant), so a
+    # single announcement ends up naming both — proving one message per match, not one per player.
+    And the Steam message in chat 2110 is edited to contain "Alpha"
+    And the Steam message in chat 2110 is edited to contain "Bravo"
 
   Scenario: the same player's repeated match gets its own announcement
     # Two distinct matches that happen to share map, mode, result and score must not be merged into

--- a/acceptance/features/game_history.feature
+++ b/acceptance/features/game_history.feature
@@ -12,7 +12,7 @@ Feature: CS2 game history
     And Steam reports user "76561198000000910" playing CS2 with score "16-14" on map "Inferno"
     Then chat 2101 receives a Steam message containing "is playing Counter-Strike"
     When Steam reports user "76561198000000910" stopped playing
-    Then chat 2101 eventually receives a new Steam message containing "finished a game"
+    Then chat 2101 eventually receives a new Steam message containing "won a game"
     And chat 2101 eventually receives a new Steam message containing "Inferno"
     When the user sends "/game_history"
     Then the bot reply contains "🏆"
@@ -28,7 +28,7 @@ Feature: CS2 game history
     And Steam reports user "76561198000000912" playing CS2 with score "14-16" on map "Mirage"
     And a moment passes
     And Steam reports user "76561198000000912" playing CS2 with score "1-0" on map "Mirage"
-    Then chat 2103 eventually receives a new Steam message containing "finished a game"
+    Then chat 2103 eventually receives a new Steam message containing "lost a game"
     When the user sends "/game_history"
     Then the bot reply contains "☠️"
     And the bot reply contains "14-16"
@@ -42,7 +42,7 @@ Feature: CS2 game history
     And Steam reports user "76561198000000913" playing CS2 with score "15-15" on map "Nuke"
     And a moment passes
     And Steam reports user "76561198000000913" playing CS2 with score "1-0" on map "Nuke"
-    Then chat 2104 eventually receives a new Steam message containing "finished a game"
+    Then chat 2104 eventually receives a new Steam message containing "tied a game"
     When the user sends "/game_history"
     Then the bot reply contains "🤝"
     And the bot reply contains "15-15"
@@ -59,7 +59,7 @@ Feature: CS2 game history
     And Steam reports user "76561198000000914" playing CS2 with score "12-5" on map "Inferno"
     And a moment passes
     And Steam reports user "76561198000000914" playing CS2 with score "1-0" on map "Inferno"
-    Then chat 2105 eventually receives a new Steam message containing "finished a game"
+    Then chat 2105 eventually receives a new Steam message containing "won a game"
     When the user sends "/game_history"
     Then the bot reply contains "12-5"
 
@@ -90,7 +90,7 @@ Feature: CS2 game history
     And Steam reports user "76561198000000930" playing CS2 with score "6-3" on map "Inferno"
     And Steam reports user "76561198000000931" stopped playing
     And Steam reports user "76561198000000930" stopped playing
-    Then chat 2106 eventually receives a new Steam message containing "finished a game"
+    Then chat 2106 eventually receives a new Steam message containing "won a game"
     When user 5930 sends "/game_history"
     Then the bot reply contains "with"
 
@@ -113,7 +113,7 @@ Feature: CS2 game history
     And Steam reports user "76561198000000950" playing CS2 with score "16-14" on map "Inferno"
     And Steam reports user "76561198000000951" playing CS2 with score "5-3" on map "Mirage"
     And Steam reports user "76561198000000950" stopped playing
-    Then chat 2108 eventually receives a new Steam message containing "finished a game"
+    Then chat 2108 eventually receives a new Steam message containing "won a game"
     When Steam reports user "76561198000000951" stopped playing
     And 8 seconds pass
     When the user sends "/game_history"
@@ -130,8 +130,25 @@ Feature: CS2 game history
     And a moment passes
     And Steam reports user "76561198000000960" playing CS2 summarised as "Competitive Inferno 8-3" with score "8-3" on map "Inferno"
     And a moment passes
-    Then chat 2109 has not received a Steam message containing "finished a game"
+    Then chat 2109 has not received a Steam message containing "won a game"
     When Steam reports user "76561198000000960" playing CS2 summarised as "Competitive Inferno 1-0" with score "1-0" on map "Inferno"
-    Then chat 2109 eventually receives a new Steam message containing "finished a game"
+    Then chat 2109 eventually receives a new Steam message containing "won a game"
     When the user sends "/game_history"
     Then the bot reply contains "8-3"
+
+  Scenario: players finishing the same match at different times share one announcement
+    # Each player's Steam presence (and finalisation) arrives separately, so the first to finish
+    # posts the message and the next edits it to add their name — one message per match, not one
+    # per player.
+    Given a chat with id 2110
+    When user 5970 sends "/steam_user_id 76561198000000970"
+    Then the bot reply contains "76561198000000970"
+    When user 5971 sends "/steam_user_id 76561198000000971"
+    Then the bot reply contains "76561198000000971"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000970" named "Alpha" playing CS2 with score "13-7" on map "Vertigo"
+    And Steam reports user "76561198000000970" stopped playing
+    And Steam reports user "76561198000000971" named "Bravo" playing CS2 with score "13-7" on map "Vertigo"
+    And Steam reports user "76561198000000971" stopped playing
+    Then chat 2110 eventually receives a new Steam message containing "won a game"
+    And the Steam message in chat 2110 is edited to contain "Alpha and Bravo"

--- a/acceptance/features/game_history.feature
+++ b/acceptance/features/game_history.feature
@@ -146,9 +146,26 @@ Feature: CS2 game history
     When user 5971 sends "/steam_user_id 76561198000000971"
     Then the bot reply contains "76561198000000971"
     When Steam mappings are refreshed
-    And Steam reports user "76561198000000970" named "Alpha" playing CS2 with score "13-7" on map "Vertigo"
+    And Steam reports user "76561198000000970" playing CS2 as "Alpha" with score "13-7" on map "Vertigo"
     And Steam reports user "76561198000000970" stopped playing
-    And Steam reports user "76561198000000971" named "Bravo" playing CS2 with score "13-7" on map "Vertigo"
+    And Steam reports user "76561198000000971" playing CS2 as "Bravo" with score "13-7" on map "Vertigo"
     And Steam reports user "76561198000000971" stopped playing
     Then chat 2110 eventually receives a new Steam message containing "won a game"
     And the Steam message in chat 2110 is edited to contain "Alpha and Bravo"
+
+  Scenario: the same player's repeated match gets its own announcement
+    # Two distinct matches that happen to share map, mode, result and score must not be merged into
+    # one message just because they look alike — each real match is announced separately.
+    Given a chat with id 2111
+    And a user with id 5980 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000980"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000980"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000980" playing CS2 with score "13-7" on map "Vertigo"
+    And Steam reports user "76561198000000980" stopped playing
+    And 8 seconds pass
+    Then chat 2111 eventually receives a new Steam message containing "won a game"
+    When Steam reports user "76561198000000980" playing CS2 with score "13-7" on map "Vertigo"
+    And Steam reports user "76561198000000980" stopped playing
+    And 8 seconds pass
+    Then chat 2111 has received 2 Steam messages containing "won a game"

--- a/acceptance/features/steps/steam_steps.py
+++ b/acceptance/features/steps/steam_steps.py
@@ -64,6 +64,23 @@ def step_seconds_pass(context: Context, seconds: int) -> None:
     time.sleep(seconds)
 
 
+# Same as the score+map step but with an explicit Steam display name, so a test can assert that
+# distinct players are named in a grouped end-of-game announcement. "named" sits before "playing"
+# so the plainer step can't match this sentence.
+@when('Steam reports user "{steam_id}" named "{name}" playing CS2 with score "{score}" on map "{map_name}"')
+def step_steam_named_playing_map_score(context: Context, steam_id: str, name: str, score: str, map_name: str) -> None:
+    _capture_steam_baseline(context)
+    helpers.steam_emit_user(steam_id, {
+        "player_name": name,
+        "gameid": "730",
+        "rich_presence": [
+            {"key": "game:map", "value": map_name},
+            {"key": "status", "value": "Competitive"},
+            {"key": "game:score", "value": score},
+        ],
+    })
+
+
 # A varying "summarised as" rich_presence_string with a stable "Competitive" status: the game
 # mode must come from the stable status, not the changing summary, or the match would split.
 # "summarised as" sits before "with score" so the existing score/map step can't greedily match.

--- a/acceptance/features/steps/steam_steps.py
+++ b/acceptance/features/steps/steam_steps.py
@@ -65,9 +65,10 @@ def step_seconds_pass(context: Context, seconds: int) -> None:
 
 
 # Same as the score+map step but with an explicit Steam display name, so a test can assert that
-# distinct players are named in a grouped end-of-game announcement. "named" sits before "playing"
-# so the plainer step can't match this sentence.
-@when('Steam reports user "{steam_id}" named "{name}" playing CS2 with score "{score}" on map "{map_name}"')
+# distinct players are named in a grouped end-of-game announcement. The name sits BETWEEN
+# "playing CS2" and "with score" (like the "summarised as" step) so the plainer score/map step's
+# tail isn't a substring of this sentence — otherwise behave reports an ambiguous step.
+@when('Steam reports user "{steam_id}" playing CS2 as "{name}" with score "{score}" on map "{map_name}"')
 def step_steam_named_playing_map_score(context: Context, steam_id: str, name: str, score: str, map_name: str) -> None:
     _capture_steam_baseline(context)
     helpers.steam_emit_user(steam_id, {
@@ -172,6 +173,23 @@ def step_chat_has_not_received(context: Context, chat_id: int, expected: str) ->
     outbox: List[Dict[str, Any]] = helpers.get_outbox(chat_id)
     bad: List[str] = [m["text"] for m in outbox if m["method"] == "sendMessage" and expected in m["text"]]
     assert not bad, f"Expected no Steam message containing {expected!r}, but got: {bad!r}"
+
+
+@then('chat {chat_id:d} has received {count:d} Steam messages containing "{expected}"')
+def step_chat_received_count(context: Context, chat_id: int, count: int, expected: str) -> None:
+    # Count fresh sendMessage calls (not edits) matching the text. Used to prove distinct matches
+    # get distinct announcements rather than one being edited into another.
+    deadline: float = time.time() + helpers.REPLY_TIMEOUT
+    found: int = 0
+    while time.time() < deadline:
+        outbox: List[Dict[str, Any]] = helpers.get_outbox(chat_id)
+        found = len([m for m in outbox if m["method"] == "sendMessage" and expected in m["text"]])
+        if found >= count:
+            break
+        time.sleep(helpers.POLL_INTERVAL)
+    assert found == count, (
+        f"Expected {count} Steam messages containing {expected!r} in chat {chat_id}, found {found}"
+    )
 
 
 @then('the Steam message in chat {chat_id:d} is edited to contain "{expected}"')

--- a/dao/Database.ts
+++ b/dao/Database.ts
@@ -84,13 +84,42 @@ const migrateLegacyCurrentMatch = async (conn: PoolConnection): Promise<void> =>
     }
 };
 
+// One-off, idempotent migration: add the columns that back grouped end-of-game announcements
+// (game_history.player_name and .message_id) to databases created before they existed. CREATE
+// TABLE IF NOT EXISTS won't alter an existing table, so add each column when it's missing.
+// Portable across MariaDB/MySQL (no ADD COLUMN IF NOT EXISTS).
+const migrateGameHistoryAnnouncementColumns = async (conn: PoolConnection): Promise<void> => {
+    const columnExists = async (column: string): Promise<boolean> => {
+        const [rows] = await conn.query<RowDataPacket[]>(
+            'SELECT COUNT(*) AS col FROM information_schema.COLUMNS ' +
+            ' WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :table AND COLUMN_NAME = :column',
+            { table: 'game_history', column }
+        );
+        return Number(rows[0]?.col) > 0;
+    };
+    const [tblRows] = await conn.query<RowDataPacket[]>(
+        'SELECT COUNT(*) AS tbl FROM information_schema.TABLES ' +
+        " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'game_history'"
+    );
+    if (Number(tblRows[0]?.tbl) === 0) return;
+    if (!(await columnExists('player_name'))) {
+        console.log('Adding game_history.player_name for grouped end-of-game announcements.');
+        await conn.query('ALTER TABLE game_history ADD COLUMN player_name VARCHAR(255) NULL');
+    }
+    if (!(await columnExists('message_id'))) {
+        console.log('Adding game_history.message_id for grouped end-of-game announcements.');
+        await conn.query('ALTER TABLE game_history ADD COLUMN message_id BIGINT NULL');
+    }
+};
+
 // Create any missing tables. Idempotent (every statement is CREATE TABLE IF NOT EXISTS, plus
-// a guarded one-off rebuild of the transient current_match tables when their shape changed).
+// guarded one-off migrations for shape changes the CREATE statements can't apply in place).
 export const ensureSchema = async (): Promise<void> => {
     const ddl = readFileSync(join(import.meta.dirname, 'schema.sql'), 'utf-8');
     const conn = await getPool().getConnection();
     try {
         await migrateLegacyCurrentMatch(conn);
+        await migrateGameHistoryAnnouncementColumns(conn);
         for (const statement of splitStatements(ddl)) {
             await conn.query(statement);
         }

--- a/dao/Database.ts
+++ b/dao/Database.ts
@@ -101,7 +101,9 @@ const migrateGameHistoryAnnouncementColumns = async (conn: PoolConnection): Prom
         'SELECT COUNT(*) AS tbl FROM information_schema.TABLES ' +
         " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'game_history'"
     );
-    if (Number(tblRows[0]?.tbl) === 0) return;
+    if (Number(tblRows[0]?.tbl) === 0) {
+        return;
+    }
     if (!(await columnExists('player_name'))) {
         console.log('Adding game_history.player_name for grouped end-of-game announcements.');
         await conn.query('ALTER TABLE game_history ADD COLUMN player_name VARCHAR(255) NULL');

--- a/dao/GameHistoryDAO.ts
+++ b/dao/GameHistoryDAO.ts
@@ -10,12 +10,25 @@ export interface GameHistoryCoPlayer {
 export interface GameHistoryEntry {
     chat_id: number;
     user_id: number;
+    player_name?: string;  // owner's resolved display name at match end, for grouped announcements
     mode?: string;
     map?: string;
     score?: string;        // raw final score, e.g. "16-14"
     co_players: GameHistoryCoPlayer[];
     started_at?: Date;
     ended_at: Date;
+}
+
+// A recently-finished match used for grouping a per-match end-of-game announcement: the owner (with
+// the display name resolved at match end), the match's raw score, its co-players, and the Telegram
+// id of the shared announcement (if one has been posted).
+export interface SiblingMatch {
+    id: number;
+    user_id: number;
+    player_name?: string;
+    score?: string;
+    message_id: number | null;
+    co_players: GameHistoryCoPlayer[];
 }
 
 // The match a Steam account is currently playing, surfaced in a chat. Keyed by
@@ -84,15 +97,18 @@ class GameHistoryDAO {
         return order.map(id => byId.get(id)!);
     }
 
-    addGameHistoryEntry(entry: GameHistoryEntry): Promise<void> {
+    // Insert a finished match (and its co-players); returns the new game_history id so the caller
+    // can later attach the id of the grouped end-of-game announcement.
+    addGameHistoryEntry(entry: GameHistoryEntry): Promise<number> {
         return withTransaction(async conn => {
             await ensureTelegramUser(conn, entry.user_id);
             const [res] = await conn.query<ResultSetHeader>(
-                'INSERT INTO game_history (chat_id, user_id, mode, map, score, started_at, ended_at) ' +
-                'VALUES (:chat_id, :user_id, :mode, :map, :score, :started_at, :ended_at)',
+                'INSERT INTO game_history (chat_id, user_id, player_name, mode, map, score, started_at, ended_at) ' +
+                'VALUES (:chat_id, :user_id, :player_name, :mode, :map, :score, :started_at, :ended_at)',
                 {
                     chat_id: entry.chat_id,
                     user_id: entry.user_id,
+                    player_name: entry.player_name ?? null,
                     mode: entry.mode ?? null,
                     map: entry.map ?? null,
                     score: entry.score ?? null,
@@ -108,7 +124,55 @@ class GameHistoryDAO {
                     { game_history_id: historyId, co_user_id: co.tg_user_id, name: co.name ?? null }
                 );
             }
+            return historyId;
         });
+    }
+
+    // Recently-finished matches in a chat on a given map+mode, each with its co-players and the id
+    // of the grouped end-of-game message (if one has been posted). Used to group a just-finalised
+    // match with sibling finalisations of the same match and to edit their shared announcement.
+    async getRecentSiblingMatches(chat_id: number, map: string | undefined, mode: string | undefined, since: Date): Promise<SiblingMatch[]> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT h.id, h.user_id, h.player_name, h.score, h.message_id, c.co_user_id, c.name AS co_name ' +
+            'FROM game_history h ' +
+            'LEFT JOIN game_history_coplayer c ON c.game_history_id = h.id ' +
+            'WHERE h.chat_id = :chat_id AND h.ended_at >= :since ' +
+            '  AND ((:map IS NULL AND h.map IS NULL) OR h.map = :map) ' +
+            '  AND ((:mode IS NULL AND h.mode IS NULL) OR h.mode = :mode) ' +
+            'ORDER BY h.id ASC',
+            { chat_id, map: map ?? null, mode: mode ?? null, since }
+        );
+
+        const byId = new Map<number, SiblingMatch>();
+        const order: number[] = [];
+        for (const row of rows) {
+            const id = Number(row.id);
+            let sib = byId.get(id);
+            if (!sib) {
+                sib = {
+                    id,
+                    user_id: Number(row.user_id),
+                    player_name: row.player_name ?? undefined,
+                    score: row.score ?? undefined,
+                    message_id: row.message_id == null ? null : Number(row.message_id),
+                    co_players: []
+                };
+                byId.set(id, sib);
+                order.push(id);
+            }
+            const co = this._coPlayerFromRow(row);
+            if (co) {
+                sib.co_players.push(co);
+            }
+        }
+        return order.map(id => byId.get(id)!);
+    }
+
+    setGameHistoryMessageId(id: number, message_id: number): Promise<void> {
+        return query<ResultSetHeader>(
+            'UPDATE game_history SET message_id = :message_id WHERE id = :id',
+            { id, message_id }
+        ).then(() => undefined);
     }
 
     private async _loadCurrentMatchCoPlayers(chat_id: number, steam_id: string): Promise<GameHistoryCoPlayer[]> {

--- a/dao/schema.sql
+++ b/dao/schema.sql
@@ -170,18 +170,24 @@ CREATE TABLE IF NOT EXISTS current_match_coplayer (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- A finished match. score is the raw "16-14" (player-opponent); win/loss/tie is derived
--- from it. One row per finished match per (chat,user).
+-- from it. One row per finished match per (chat,user). player_name is the owner's display name
+-- resolved at match end (so a grouped announcement can name every player without re-resolving).
+-- message_id is the Telegram id of the single per-match end-of-game announcement shared by every
+-- player of the same match (set on the first finaliser's row, then copied onto each later one).
 CREATE TABLE IF NOT EXISTS game_history (
-    id         BIGINT       NOT NULL AUTO_INCREMENT,
-    chat_id    BIGINT       NOT NULL,
-    user_id    BIGINT       NOT NULL,
-    mode       VARCHAR(255) NULL,
-    map        VARCHAR(64)  NULL,
-    score      VARCHAR(64)  NULL,
-    started_at DATETIME(3)  NULL,
-    ended_at   DATETIME(3)  NOT NULL,
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    chat_id     BIGINT       NOT NULL,
+    user_id     BIGINT       NOT NULL,
+    player_name VARCHAR(255) NULL,
+    mode        VARCHAR(255) NULL,
+    map         VARCHAR(64)  NULL,
+    score       VARCHAR(64)  NULL,
+    message_id  BIGINT       NULL,
+    started_at  DATETIME(3)  NULL,
+    ended_at    DATETIME(3)  NOT NULL,
     PRIMARY KEY (id),
     KEY idx_game_history_chat_user (chat_id, user_id),
+    KEY idx_game_history_grouping (chat_id, ended_at),
     CONSTRAINT fk_game_history_user FOREIGN KEY (user_id)
         REFERENCES telegram_user (user_id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
Several tracked players in the same chat finishing the same CS2 match each
got their own "finished a game" message. Their Steam presence (and thus each
finalisation) arrives with different, often large delays, so the messages
couldn't simply be merged at post time.

Post a single per-match announcement on the first player's finalise and edit
it to add each further player as their finalise arrives, e.g.

  🏆 Seppe, Robin and RanSEMware won a game on de_vertigo (competitive): ...
  ☠️ Robin and Seppe lost a game on de_anubis (competitive): ...

The result emoji and a won/lost/tied verb lead the message; player order is
irrelevant.

Same-match siblings are the recently-finalised game_history rows in the chat
sharing map + mode + win/loss/tie result with a round total within tolerance
(no co-player linkage required, since delays often leave it empty). The
participant list is derived from those rows — no new table. game_history
gains player_name (owner's display name resolved at finalise, so siblings can
be named without re-resolving) and message_id (the shared announcement),
added via a guarded, portable migration. Announcing is serialised per chat so
concurrent finalises can't each create a message.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014F9dHxrpEcrWtC9NLaLRvn