### PR TITLE
Derive matches from an append-only presence event log

### DIFF
--- a/SteamService.ts
+++ b/SteamService.ts
@@ -612,75 +612,81 @@ class SteamService {
         }
         const { closed } = segmentStream(events, new Date(), DERIVATION_CONFIG);
         for (const segment of closed) {
-            await this.finalizeSegment(steamId, segment);
+            try {
+                await this.finalizeSegment(steamId, segment);
+            } catch (err) {
+                // Stop at the first failed segment: a later segment's cursor advance would skip
+                // past this one and its match would never be recorded. Left unfinalised, it is
+                // retried on the next derivation (every event and every sweep tick).
+                console.error(`Failed to finalise match for Steam ID ${steamId}; will retry:`, err);
+                break;
+            }
         }
     }
 
     // Record a finished match segment to history for each of the owner's chats (advancing the
     // stream cursor in the same transaction, which is what makes finalisation exactly-once) and
-    // post/extend the end-of-game announcement where the chat allows it.
+    // post/extend the end-of-game announcement where the chat allows it. Throws if the match
+    // could not be recorded (so the caller stops and the segment is retried later); announcement
+    // failures are contained per chat since by then the cursor has already advanced.
     private async finalizeSegment(steamId: string, segment: MatchSegment): Promise<void> {
         const tgUserId = segment.user_id;
-        try {
-            const entries: { chatId: number; entry: GameHistoryEntry }[] = [];
+        const entries: { chatId: number; entry: GameHistoryEntry }[] = [];
 
             if (segment.max_score) {
-                const coPlayers = await this.findSegmentCoPlayers(steamId, segment);
-                const chats = await this.userDao.getUserChats(tgUserId);
-                for (const chatId of chats) {
-                    // Resolve and store the owner's display name now so a later-finalising player
-                    // of the same match can render it into the shared announcement without having
-                    // to re-resolve it. Co-players must share the chat.
-                    const playerName = (await this.getTelegramDisplayName(chatId, tgUserId)) || segment.player_name || String(tgUserId);
-                    const chatCoPlayers: GameHistoryCoPlayer[] = [];
-                    for (const co of coPlayers) {
-                        const coChats = await this.userDao.getUserChats(co.user_id);
-                        if (!coChats.includes(chatId)) continue;
-                        const name = await this.resolveCoPlayerName(chatId, co.user_id, co.player_name);
-                        chatCoPlayers.push({ tg_user_id: co.user_id, name });
+            const coPlayers = await this.findSegmentCoPlayers(steamId, segment);
+            const chats = await this.userDao.getUserChats(tgUserId);
+            for (const chatId of chats) {
+                // Resolve and store the owner's display name now so a later-finalising player
+                // of the same match can render it into the shared announcement without having
+                // to re-resolve it. Co-players must share the chat.
+                const playerName = (await this.getTelegramDisplayName(chatId, tgUserId)) || segment.player_name || String(tgUserId);
+                const chatCoPlayers: GameHistoryCoPlayer[] = [];
+                for (const co of coPlayers) {
+                    const coChats = await this.userDao.getUserChats(co.user_id);
+                    if (!coChats.includes(chatId)) continue;
+                    const name = await this.resolveCoPlayerName(chatId, co.user_id, co.player_name);
+                    chatCoPlayers.push({ tg_user_id: co.user_id, name });
+                }
+                entries.push({
+                    chatId,
+                    entry: {
+                        chat_id: chatId,
+                        user_id: tgUserId,
+                        player_name: playerName,
+                        mode: segment.mode,
+                        map: segment.map,
+                        score: segment.max_score,
+                        co_players: chatCoPlayers,
+                        started_at: segment.started_at,
+                        ended_at: new Date()
                     }
-                    entries.push({
-                        chatId,
-                        entry: {
-                            chat_id: chatId,
-                            user_id: tgUserId,
-                            player_name: playerName,
-                            mode: segment.mode,
-                            map: segment.map,
-                            score: segment.max_score,
-                            co_players: chatCoPlayers,
-                            started_at: segment.started_at,
-                            ended_at: new Date()
-                        }
-                    });
-                }
+                });
             }
+        }
 
-            const historyIds = await withTransaction(async conn => {
-                const ids: number[] = [];
-                for (const { entry } of entries) {
-                    ids.push(await this.gameHistoryDao.addGameHistoryEntry(entry, conn));
-                }
-                await this.presenceEventDao.advanceCursor(conn, steamId, segment.lastEventId);
-                return ids;
-            });
-
-            for (let i = 0; i < entries.length; i++) {
-                const { chatId, entry } = entries[i];
-                try {
-                    const chatSettings: ChatSettings = await this.chatDao.getChatSettings(chatId);
-                    if (chatSettings.steam_updates !== false) {
-                        // Serialise announcing per chat so two players finalising the same match
-                        // concurrently can't each create a separate message.
-                        await this.withLock(`eog_${chatId}`, () =>
-                            this.announceFinishedMatch(chatId, historyIds[i], entry));
-                    }
-                } catch (err) {
-                    console.error(`Failed to announce finished match in chat ${chatId}:`, err);
-                }
+        const historyIds = await withTransaction(async conn => {
+            const ids: number[] = [];
+            for (const { entry } of entries) {
+                ids.push(await this.gameHistoryDao.addGameHistoryEntry(entry, conn));
             }
-        } catch (err) {
-            console.error(`Failed to finalise match for user ${tgUserId} (Steam ID ${steamId}):`, err);
+            await this.presenceEventDao.advanceCursor(conn, steamId, segment.lastEventId);
+            return ids;
+        });
+
+        for (let i = 0; i < entries.length; i++) {
+            const { chatId, entry } = entries[i];
+            try {
+                const chatSettings: ChatSettings = await this.chatDao.getChatSettings(chatId);
+                if (chatSettings.steam_updates !== false) {
+                    // Serialise announcing per chat so two players finalising the same match
+                    // concurrently can't each create a separate message.
+                    await this.withLock(`eog_${chatId}`, () =>
+                        this.announceFinishedMatch(chatId, historyIds[i], entry));
+                }
+            } catch (err) {
+                console.error(`Failed to announce finished match in chat ${chatId}:`, err);
+            }
         }
     }
 

--- a/SteamService.ts
+++ b/SteamService.ts
@@ -4,11 +4,16 @@ import TelegramBot from 'node-telegram-bot-api';
 import UserDAO, { UserSettings } from './dao/UserDAO.js';
 import ChatDAO, { ChatSettings } from './dao/ChatDAO.js';
 import GameUpdateDAO, { GameUpdate } from './dao/GameUpdateDAO.js';
-import GameHistoryDAO, { CurrentMatch, GameHistoryEntry, GameHistoryCoPlayer, SiblingMatch } from './dao/GameHistoryDAO.js';
+import GameHistoryDAO, { GameHistoryEntry, GameHistoryCoPlayer, SiblingMatch } from './dao/GameHistoryDAO.js';
+import PresenceEventDAO from './dao/PresenceEventDAO.js';
 import RollcallPlayerDAO from './dao/RollcallPlayerDAO.js';
 import { escapeMarkdown } from './utils.js';
 import { parseMention } from './rsvp.js';
-import { saveSteamFile, readSteamFile } from './dao/Database.js';
+import { saveSteamFile, readSteamFile, withTransaction } from './dao/Database.js';
+import {
+    segmentStream, findCoPlayers, parseRawScore as parseRawScoreFn,
+    DerivationConfig, MatchSegment, PresenceEvent
+} from './matchDerivation.js';
 
 // A finished match with no further score progress is recorded once it has been idle
 // (CS2 not running, score unchanged) for this long. Overridable for tests.
@@ -25,6 +30,24 @@ const EOG_GROUP_WINDOW_MS = Number(process.env.EOG_GROUP_WINDOW_MS) || 2 * 60 * 
 // How far a freshly reported round-total may dip below the running match total before we
 // treat it as a brand new match rather than out-of-order update noise.
 const RESET_TOLERANCE = 2;
+
+// How long an uncontradicted score reset must stand before the old match is finalised. A dip
+// that returns to the old range within this window is folded away as presence noise instead of
+// splitting the match. Overridable for tests.
+const MATCH_RESET_CONFIRM_MS = Number(process.env.MATCH_RESET_CONFIRM_MS) || 30 * 1000;
+
+// How long raw presence events are kept after they've been finalised into history. The log is
+// what makes retrospective (re-)derivation possible, so keep a forensically useful window.
+const PRESENCE_EVENT_TTL_MS = Number(process.env.PRESENCE_EVENT_TTL_MS) || 7 * 24 * 60 * 60 * 1000;
+
+// How often, at most, the presence-event TTL prune runs (piggybacked on the sweep timer).
+const PRESENCE_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+
+const DERIVATION_CONFIG: DerivationConfig = {
+    resetTolerance: RESET_TOLERANCE,
+    matchIdleMs: MATCH_IDLE_MS,
+    resetConfirmMs: MATCH_RESET_CONFIRM_MS
+};
 
 interface GameUpdateInfo {
     gameId?: string | number;
@@ -55,14 +78,16 @@ class SteamService {
     private chatDao: ChatDAO;
     private gameUpdateDao: GameUpdateDAO;
     private gameHistoryDao: GameHistoryDAO;
+    private presenceEventDao: PresenceEventDAO;
     private rollcallPlayerDao: RollcallPlayerDAO;
     private steamToTelegram: Record<string, number>;
     private appIdCS2: number;
     private steamGuardCallback: ((code: string) => void) | null;
     private telegramNameCache: Record<string, { name: string; fetchedAt: number }> = {};
-    // Serialises read-modify-write of a (chat,user)'s match buffer so rapidly-arriving
-    // presence updates can't race (a score reset finalising before a continuation persists).
+    // Serialises append+derive+finalise per Steam account (and announcement editing per chat)
+    // so rapidly-arriving presence updates and the sweep can't race each other.
     private matchLocks: Record<string, Promise<unknown>> = {};
+    private lastPresencePruneAt: number = 0;
     private friendsListLoaded: boolean = false;
     private adminUserId: string | undefined;
     private updateInterval: NodeJS.Timeout | null;
@@ -100,6 +125,7 @@ class SteamService {
         this.chatDao = new ChatDAO();
         this.gameUpdateDao = new GameUpdateDAO();
         this.gameHistoryDao = new GameHistoryDAO();
+        this.presenceEventDao = new PresenceEventDAO();
         this.rollcallPlayerDao = new RollcallPlayerDAO();
         this.steamToTelegram = {};
         this.appIdCS2 = 730;
@@ -282,12 +308,14 @@ class SteamService {
                 console.debug(`User ${playerName} (${steamId}) is not playing anything, ignoring.`);
             }
 
+            // Record that THIS account stopped playing — a match can't continue on another
+            // account, so a sibling account staying in CS2 is irrelevant. This is never a match
+            // boundary by itself (a relaunch on the same account resumes the match); the sweep
+            // finalises the match once it has been idle past the window.
+            await this.recordPresence(steamId, tgUserId, { playing: false });
+
             const chats = await this.userDao.getUserChats(tgUserId);
             for (const chatId of chats) {
-                // Mark THIS account's match idle — a match can't continue on another account,
-                // so a sibling account staying in CS2 is irrelevant. A relaunch on this same
-                // account will resume it; otherwise the sweep finalises it after the idle window.
-                await this.markMatchNotPlaying(chatId, steamId);
                 // The live message is per-user, so it only closes once no account is playing.
                 await this.maybeCloseSession(chatId, tgUserId);
             }
@@ -341,16 +369,16 @@ class SteamService {
 
         const info: GameUpdateInfo = { gameId, map, status, score };
 
+        // Record the presence transition and derive match progress / boundaries from the stream,
+        // regardless of any chat's live-update setting; history is a separate pull
+        // (/game_history) and the end-of-game notification is gated per chat at finalisation.
+        await this.recordPresence(steamId, tgUserId, { playing: true, map, mode, rawScore, playerName });
+
         const chats = await this.userDao.getUserChats(tgUserId);
         if (chats.length === 0) {
             console.debug(`No chats found for user ${tgUserId} (Steam ID: ${steamId}). Cannot publish update.`);
         }
         for (const chatId of chats) {
-            // Track match progress / boundaries regardless of the chat's live-update setting;
-            // history is a separate pull (/game_history) and the end-of-game notification is
-            // gated by steam_updates inside finalizeMatch.
-            await this.updateMatchState(chatId, steamId, tgUserId, { map, mode, rawScore, playerName });
-
             const chatSettings: ChatSettings = await this.chatDao.getChatSettings(chatId);
             if (chatSettings.steam_updates === false) {
                 console.debug(`Steam updates are disabled for chat ${chatId}. Skipping update for user ${tgUserId}.`);
@@ -499,12 +527,7 @@ class SteamService {
 
     // Parse a raw "16-14" (or "16:14") score into its parts and round total.
     parseRawScore(score?: string): { a: number; b: number; total: number } | null {
-        if (!score) return null;
-        const m = score.replace(/[\[\]]/g, '').trim().match(/^(\d+)\s*[-:]\s*(\d+)$/);
-        if (!m) return null;
-        const a = parseInt(m[1], 10);
-        const b = parseInt(m[2], 10);
-        return { a, b, total: a + b };
+        return parseRawScoreFn(score);
     }
 
     // 🏆/☠️/🤝 from a raw score (first part = player, second = opponents).
@@ -516,26 +539,6 @@ class SteamService {
         return '🤝';
     }
 
-    // Pull map / mode / round-total out of a steam-user presence object (used when looking at
-    // other tracked players to decide who is in the same match).
-    private extractMapModeTotal(user: any): { map?: string; mode?: string; total?: number } {
-        let map: string | undefined, status: string | undefined, score: string | undefined, mode: string | undefined;
-        const rp = user?.rich_presence;
-        if (Array.isArray(rp)) {
-            map = rp.find((i: SteamRichPresenceItem) => i.key === 'game:map' || i.key === 'map')?.value;
-            status = rp.find((i: SteamRichPresenceItem) => i.key === 'status')?.value;
-            score = rp.find((i: SteamRichPresenceItem) => i.key === 'game:score' || i.key === 'score')?.value;
-            mode = rp.find((i: SteamRichPresenceItem) => i.key === 'game:mode' || i.key === 'mode')?.value;
-        } else if (rp && typeof rp === 'object') {
-            map = rp['game:map'] || rp['map'];
-            status = rp['status'];
-            score = rp['game:score'] || rp['score'];
-            mode = rp['game:mode'] || rp['mode'];
-        }
-        if (!mode) mode = status;
-        return { map, mode, total: this.parseRawScore(score)?.total };
-    }
-
     // Run fn with exclusive access to a named lock, chaining onto any in-flight operation for the
     // same key so concurrent callers are serialised.
     private withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
@@ -545,109 +548,156 @@ class SteamService {
         return run;
     }
 
-    // Run fn with exclusive access to a (chat,Steam account)'s match buffer, chaining onto any
-    // in-flight operation for the same key so concurrent presence updates are applied in series.
-    private withMatchLock<T>(chatId: number, steamId: string, fn: () => Promise<T>): Promise<T> {
-        return this.withLock(`${chatId}_${steamId}`, fn);
+    // Run fn with exclusive access to a Steam account's event stream, chaining onto any in-flight
+    // operation for the same account so presence updates and the sweep are applied in series.
+    private withStreamLock<T>(steamId: string, fn: () => Promise<T>): Promise<T> {
+        return this.withLock(`stream_${steamId}`, fn);
     }
 
-    // Update the persisted "current match" buffer for a (chat, Steam account) from a presence
-    // tick, detecting match boundaries (score reset / map change / mode change) and accumulating
-    // co-players. Finalises the previous match when a boundary is crossed. Keyed by Steam
-    // account so a user's linked accounts are tracked as independent matches.
-    private updateMatchState(chatId: number, steamId: string, tgUserId: number, info: { map?: string; mode?: string; rawScore?: string; playerName?: string }): Promise<void> {
-      return this.withMatchLock(chatId, steamId, async () => {
-        try {
-            const { map, mode, rawScore, playerName } = info;
-            const cur = await this.gameHistoryDao.getCurrentMatch(chatId, steamId);
-            const newParsed = this.parseRawScore(rawScore);
+    // Record a presence transition for a Steam account and re-derive its match state from the
+    // stream. Only transitions are stored: a snapshot identical to the stream's last event
+    // (same playing flag, map, mode and score) is dropped, so pure re-broadcasts — including
+    // updates carrying nothing but the game id — never grow the log.
+    private recordPresence(
+        steamId: string,
+        tgUserId: number,
+        snapshot: { playing: boolean; map?: string; mode?: string; rawScore?: string; playerName?: string }
+    ): Promise<void> {
+        return this.withStreamLock(steamId, async () => {
+            try {
+                const last = await this.presenceEventDao.getLastEvent(steamId);
 
-            if (cur) {
-                const mapChanged = !!(map && cur.map && map.toLowerCase() !== cur.map.toLowerCase());
-                const modeChanged = !!(mode && cur.mode && mode !== cur.mode);
-                const curParsed = this.parseRawScore(cur.max_score);
-                const scoreReset = !!(newParsed && curParsed && newParsed.total < curParsed.total - RESET_TOLERANCE);
-
-                if (!mapChanged && !modeChanged && !scoreReset) {
-                    // Continuation of the same match (incl. a relaunch resuming it).
-                    let max_score = cur.max_score;
-                    if (newParsed && (!curParsed || newParsed.total > curParsed.total)) {
-                        max_score = rawScore;
+                if (!snapshot.playing) {
+                    // Only a playing→stopped transition is worth recording; for an account with
+                    // no (playing) history, "still not in CS2" is not an event.
+                    if (!last || !last.playing) {
+                        return;
                     }
-                    const matchMap = cur.map || map;
-                    const matchMode = cur.mode || mode;
-                    const incoming = await this.collectCoPlayers(chatId, tgUserId, matchMap, matchMode, this.parseRawScore(max_score)?.total);
-                    await this.gameHistoryDao.setCurrentMatch({
-                        chat_id: chatId,
-                        steam_id: steamId,
-                        user_id: tgUserId,
-                        map: matchMap,
-                        mode: matchMode,
-                        max_score,
-                        player_name: playerName || cur.player_name,
-                        co_players: this.mergeCoPlayers(cur.co_players, incoming),
-                        started_at: cur.started_at,
-                        last_progress_at: new Date(),
-                        playing: true
-                    });
-                    return;
+                } else if (
+                    last && last.playing &&
+                    (last.map ?? null) === (snapshot.map ?? null) &&
+                    (last.mode ?? null) === (snapshot.mode ?? null) &&
+                    (last.raw_score ?? null) === (snapshot.rawScore ?? null)
+                ) {
+                    return; // no transition
                 }
 
-                // Boundary: the previous match is finished. Record it, then start fresh.
-                await this.finalizeMatch(cur);
+                await this.presenceEventDao.appendEvent({
+                    steam_id: steamId,
+                    user_id: tgUserId,
+                    playing: snapshot.playing,
+                    map: snapshot.map,
+                    mode: snapshot.mode,
+                    raw_score: snapshot.rawScore,
+                    score_total: this.parseRawScore(snapshot.rawScore)?.total ?? null,
+                    player_name: snapshot.playerName,
+                    created_at: new Date()
+                });
+
+                await this.deriveAndFinalize(steamId);
+            } catch (err) {
+                console.error(`Error recording presence for Steam ID ${steamId} (user ${tgUserId}):`, err);
+            }
+        });
+    }
+
+    // Replay the stream's unfinalised events and finalise every segment the derivation considers
+    // finished. Must run under the stream's lock. Idempotent: only closed segments have side
+    // effects, closing is monotone in (events, time), and finalisation advances the cursor.
+    private async deriveAndFinalize(steamId: string): Promise<void> {
+        const cursor = await this.presenceEventDao.getCursor(steamId);
+        const events = await this.presenceEventDao.getEventsAfter(steamId, cursor);
+        if (events.length === 0) {
+            return;
+        }
+        const { closed } = segmentStream(events, new Date(), DERIVATION_CONFIG);
+        for (const segment of closed) {
+            await this.finalizeSegment(steamId, segment);
+        }
+    }
+
+    // Record a finished match segment to history for each of the owner's chats (advancing the
+    // stream cursor in the same transaction, which is what makes finalisation exactly-once) and
+    // post/extend the end-of-game announcement where the chat allows it.
+    private async finalizeSegment(steamId: string, segment: MatchSegment): Promise<void> {
+        const tgUserId = segment.user_id;
+        try {
+            const entries: { chatId: number; entry: GameHistoryEntry }[] = [];
+
+            if (segment.max_score) {
+                const coPlayers = await this.findSegmentCoPlayers(steamId, segment);
+                const chats = await this.userDao.getUserChats(tgUserId);
+                for (const chatId of chats) {
+                    // Resolve and store the owner's display name now so a later-finalising player
+                    // of the same match can render it into the shared announcement without having
+                    // to re-resolve it. Co-players must share the chat.
+                    const playerName = (await this.getTelegramDisplayName(chatId, tgUserId)) || segment.player_name || String(tgUserId);
+                    const chatCoPlayers: GameHistoryCoPlayer[] = [];
+                    for (const co of coPlayers) {
+                        const coChats = await this.userDao.getUserChats(co.user_id);
+                        if (!coChats.includes(chatId)) continue;
+                        const name = await this.resolveCoPlayerName(chatId, co.user_id, co.player_name);
+                        chatCoPlayers.push({ tg_user_id: co.user_id, name });
+                    }
+                    entries.push({
+                        chatId,
+                        entry: {
+                            chat_id: chatId,
+                            user_id: tgUserId,
+                            player_name: playerName,
+                            mode: segment.mode,
+                            map: segment.map,
+                            score: segment.max_score,
+                            co_players: chatCoPlayers,
+                            started_at: segment.started_at,
+                            ended_at: new Date()
+                        }
+                    });
+                }
             }
 
-            const coPlayers = await this.collectCoPlayers(chatId, tgUserId, map, mode, newParsed?.total);
-            const now = new Date();
-            await this.gameHistoryDao.setCurrentMatch({
-                chat_id: chatId,
-                steam_id: steamId,
-                user_id: tgUserId,
-                map,
-                mode,
-                max_score: rawScore,
-                player_name: playerName,
-                co_players: coPlayers,
-                started_at: now,
-                last_progress_at: now,
-                playing: true
+            const historyIds = await withTransaction(async conn => {
+                const ids: number[] = [];
+                for (const { entry } of entries) {
+                    ids.push(await this.gameHistoryDao.addGameHistoryEntry(entry, conn));
+                }
+                await this.presenceEventDao.advanceCursor(conn, steamId, segment.lastEventId);
+                return ids;
             });
+
+            for (let i = 0; i < entries.length; i++) {
+                const { chatId, entry } = entries[i];
+                try {
+                    const chatSettings: ChatSettings = await this.chatDao.getChatSettings(chatId);
+                    if (chatSettings.steam_updates !== false) {
+                        // Serialise announcing per chat so two players finalising the same match
+                        // concurrently can't each create a separate message.
+                        await this.withLock(`eog_${chatId}`, () =>
+                            this.announceFinishedMatch(chatId, historyIds[i], entry));
+                    }
+                } catch (err) {
+                    console.error(`Failed to announce finished match in chat ${chatId}:`, err);
+                }
+            }
         } catch (err) {
-            console.error(`Error updating match state for user ${tgUserId} (Steam ID ${steamId}) in chat ${chatId}:`, err);
+            console.error(`Failed to finalise match for user ${tgUserId} (Steam ID ${steamId}):`, err);
         }
-      });
     }
 
-    // Other tracked users currently in the same match: playing CS2, same map + mode, scores
-    // not diverging too far, and sharing this chat. Returns them as resolved co-player names.
-    private async collectCoPlayers(chatId: number, tgUserId: number, map?: string, mode?: string, total?: number): Promise<GameHistoryCoPlayer[]> {
-        const result: GameHistoryCoPlayer[] = [];
-        const seen = new Set<number>();
-        for (const [otherSteamId, otherTgId] of Object.entries(this.steamToTelegram)) {
-            if (otherTgId === tgUserId || seen.has(otherTgId)) continue;
-            const otherUser = this.client.users[otherSteamId];
-            if (!otherUser || otherUser.gameid != this.appIdCS2) continue;
-
-            const other = this.extractMapModeTotal(otherUser);
-            if (map && other.map && map.toLowerCase() !== other.map.toLowerCase()) continue;
-            if (mode && other.mode && mode !== other.mode) continue;
-            if (total != null && other.total != null && Math.abs(total - other.total) > RESET_TOLERANCE) continue;
-
-            const otherChats = await this.userDao.getUserChats(otherTgId);
-            if (!otherChats.includes(chatId)) continue;
-
-            const name = await this.resolveCoPlayerName(chatId, otherTgId, otherUser.player_name);
-            result.push({ tg_user_id: otherTgId, name });
-            seen.add(otherTgId);
+    // Reconstruct the segment's co-players from the other tracked accounts' event streams (see
+    // findCoPlayers): their state at the segment's observation points must have been in CS2 on a
+    // compatible map/mode with a score in range.
+    private async findSegmentCoPlayers(steamId: string, segment: MatchSegment): Promise<{ user_id: number; player_name?: string }[]> {
+        const otherStreams = new Map<string, PresenceEvent[]>();
+        const trackedIds = await this.presenceEventDao.getTrackedSteamIds();
+        for (const otherId of trackedIds) {
+            if (otherId === steamId) continue;
+            const stream = await this.presenceEventDao.getStreamAround(otherId, segment.started_at, segment.last_event_at);
+            if (stream.length > 0) {
+                otherStreams.set(otherId, stream);
+            }
         }
-        return result;
-    }
-
-    private mergeCoPlayers(existing: GameHistoryCoPlayer[], incoming: GameHistoryCoPlayer[]): GameHistoryCoPlayer[] {
-        const byId = new Map<number, GameHistoryCoPlayer>();
-        for (const p of existing || []) byId.set(p.tg_user_id, p);
-        for (const p of incoming || []) byId.set(p.tg_user_id, p);
-        return Array.from(byId.values());
+        return findCoPlayers(segment, otherStreams, DERIVATION_CONFIG);
     }
 
     // Resolve a co-player's display name: Telegram name → rollcall mention → Steam name → id.
@@ -666,61 +716,6 @@ class SteamService {
             console.debug(`Could not match co-player ${otherTgId} against rollcall:`, err);
         }
         return fallback || String(otherTgId);
-    }
-
-    // A Steam account stopped playing CS2: don't finalise yet (a relaunch on the same account
-    // may continue the match), just mark it idle so the sweep can finalise it after the window.
-    private markMatchNotPlaying(chatId: number, steamId: string): Promise<void> {
-        return this.withMatchLock(chatId, steamId, async () => {
-            try {
-                const cur = await this.gameHistoryDao.getCurrentMatch(chatId, steamId);
-                if (cur && cur.playing) {
-                    cur.playing = false;
-                    await this.gameHistoryDao.setCurrentMatch(cur);
-                }
-            } catch (err) {
-                console.error(`Error marking match not playing for Steam ID ${steamId} in chat ${chatId}:`, err);
-            }
-        });
-    }
-
-    // Record a finished match to history and (if the chat allows) post an end-of-game message.
-    private async finalizeMatch(match: CurrentMatch): Promise<void> {
-        const chatId = match.chat_id;
-        const tgUserId = match.user_id;
-        try {
-            if (match.max_score) {
-                // Resolve and store the owner's display name now so a later-finalising player of
-                // the same match can render this name into the shared announcement without having
-                // to re-resolve it.
-                const playerName = (await this.getTelegramDisplayName(chatId, tgUserId)) || match.player_name || String(tgUserId);
-                const entry: GameHistoryEntry = {
-                    chat_id: chatId,
-                    user_id: tgUserId,
-                    player_name: playerName,
-                    mode: match.mode,
-                    map: match.map,
-                    score: match.max_score,
-                    co_players: match.co_players || [],
-                    started_at: match.started_at,
-                    ended_at: new Date()
-                };
-                const historyId = await this.gameHistoryDao.addGameHistoryEntry(entry);
-
-                const chatSettings: ChatSettings = await this.chatDao.getChatSettings(chatId);
-                if (chatSettings.steam_updates !== false) {
-                    // Serialise announcing per chat so two players finalising the same match
-                    // concurrently can't each create a separate message.
-                    await this.withLock(`eog_${chatId}`, () =>
-                        this.announceFinishedMatch(chatId, historyId, match, playerName));
-                }
-            }
-        } catch (err) {
-            console.error(`Failed to finalise match for user ${tgUserId} in chat ${chatId}:`, err);
-        } finally {
-            // Clear the buffer either way so we never record the same match twice.
-            await this.gameHistoryDao.deleteCurrentMatch(chatId, match.steam_id).catch(() => {});
-        }
     }
 
     // win/loss/tie classification of a raw "16-14" score (player-opponent), or null if unparseable.
@@ -775,12 +770,13 @@ class SteamService {
     // match on the same map", so we only join an existing announcement that this player does not
     // already OWN a row in — a player is in any given match instance exactly once, so an existing
     // group already owned by them is a different match and must get its own message.
-    private async announceFinishedMatch(chatId: number, historyId: number, match: CurrentMatch, playerName: string): Promise<void> {
-        const result = this.matchResult(match.max_score);
+    private async announceFinishedMatch(chatId: number, historyId: number, match: GameHistoryEntry): Promise<void> {
+        const playerName = match.player_name || String(match.user_id);
+        const result = this.matchResult(match.score);
         if (!result) {
             return;
         }
-        const total = this.parseRawScore(match.max_score)?.total;
+        const total = this.parseRawScore(match.score)?.total;
 
         const since = new Date(Date.now() - EOG_GROUP_WINDOW_MS);
         const candidates = await this.gameHistoryDao.getRecentSiblingMatches(chatId, match.map, match.mode, since);
@@ -844,7 +840,7 @@ class SteamService {
             }
         }
         const names = Array.from(namesByUser.values());
-        const text = this.endOfGameText(names, result, match.map, match.mode, match.max_score);
+        const text = this.endOfGameText(names, result, match.map, match.mode, match.score);
 
         if (target) {
             try {
@@ -869,20 +865,21 @@ class SteamService {
         }
     }
 
-    // Finalise matches that have gone idle (CS2 not running, no score progress) past the window.
+    // Time-driven pass over every stream with unfinalised events: finalises trailing matches
+    // that have gone idle past the window and score resets whose confirmation window has passed
+    // (both need time, not events, to resolve). Re-deriving under the stream lock means a resume
+    // event that arrived a moment ago is always seen before a match is finalised. Also hosts the
+    // throttled TTL prune of old, already-finalised events.
     private async sweepIdleMatches(): Promise<void> {
         try {
-            const cutoff = new Date(Date.now() - MATCH_IDLE_MS);
-            const idle = await this.gameHistoryDao.getIdleMatches(cutoff);
-            for (const match of idle) {
-                await this.withMatchLock(match.chat_id, match.steam_id, async () => {
-                    // Re-read under the lock so we don't race a concurrent presence update.
-                    const cur = await this.gameHistoryDao.getCurrentMatch(match.chat_id, match.steam_id);
-                    if (cur && !cur.playing && (Date.now() - new Date(cur.last_progress_at).getTime()) > MATCH_IDLE_MS) {
-                        console.log(`Match for Steam ID ${match.steam_id} in chat ${match.chat_id} is idle; finalising.`);
-                        await this.finalizeMatch(cur);
-                    }
-                });
+            const streams = await this.presenceEventDao.getStreamsWithUnfinalizedEvents();
+            for (const steamId of streams) {
+                await this.withStreamLock(steamId, () => this.deriveAndFinalize(steamId));
+            }
+
+            if (Date.now() - this.lastPresencePruneAt >= PRESENCE_PRUNE_INTERVAL_MS) {
+                this.lastPresencePruneAt = Date.now();
+                await this.presenceEventDao.prune(new Date(Date.now() - PRESENCE_EVENT_TTL_MS));
             }
         } catch (err) {
             console.error('Error during idle match sweep:', err);

--- a/SteamService.ts
+++ b/SteamService.ts
@@ -43,10 +43,15 @@ const PRESENCE_EVENT_TTL_MS = Number(process.env.PRESENCE_EVENT_TTL_MS) || 7 * 2
 // How often, at most, the presence-event TTL prune runs (piggybacked on the sweep timer).
 const PRESENCE_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 
+// How old another account's last observation may be and still count as its "state" for
+// co-player matching (the live-presence check this replaces was at most minutes stale).
+const CO_PLAYER_STALE_MS = 15 * 60 * 1000;
+
 const DERIVATION_CONFIG: DerivationConfig = {
     resetTolerance: RESET_TOLERANCE,
     matchIdleMs: MATCH_IDLE_MS,
-    resetConfirmMs: MATCH_RESET_CONFIRM_MS
+    resetConfirmMs: MATCH_RESET_CONFIRM_MS,
+    coPlayerStaleMs: CO_PLAYER_STALE_MS
 };
 
 interface GameUpdateInfo {
@@ -212,7 +217,10 @@ class SteamService {
         });
 
         this.client.on('user', (sid: any, user: any) => {
-            this.handleUserUpdate(sid.getSteamID64(), user);
+            // Not awaited (steam-user's emitter is synchronous); catch here so a transient
+            // failure (e.g. a DB blip) can't become an unhandled rejection and kill the process.
+            this.handleUserUpdate(sid.getSteamID64(), user)
+                .catch(err => console.error(`Error handling Steam user update for ${sid.getSteamID64()}:`, err));
         });
 
         // Periodically update mappings in case new users register
@@ -611,9 +619,11 @@ class SteamService {
             return;
         }
         const { closed } = segmentStream(events, new Date(), DERIVATION_CONFIG);
+        let expectedCursor = cursor;
         for (const segment of closed) {
             try {
-                await this.finalizeSegment(steamId, segment);
+                await this.finalizeSegment(steamId, segment, expectedCursor);
+                expectedCursor = segment.lastEventId;
             } catch (err) {
                 // Stop at the first failed segment: a later segment's cursor advance would skip
                 // past this one and its match would never be recorded. Left unfinalised, it is
@@ -624,16 +634,19 @@ class SteamService {
         }
     }
 
-    // Record a finished match segment to history for each of the owner's chats (advancing the
-    // stream cursor in the same transaction, which is what makes finalisation exactly-once) and
-    // post/extend the end-of-game announcement where the chat allows it. Throws if the match
-    // could not be recorded (so the caller stops and the segment is retried later); announcement
-    // failures are contained per chat since by then the cursor has already advanced.
-    private async finalizeSegment(steamId: string, segment: MatchSegment): Promise<void> {
+    // Record a finished match segment to history for each of the owner's chats, advancing the
+    // stream cursor (compare-and-swap from expectedCursor) in the same transaction — a match is
+    // therefore *recorded* exactly once, even against a concurrent finaliser. The Telegram
+    // announcement afterwards is at-most-once per finaliser: a crash between the commit and the
+    // send loses it, which is accepted (the alternative, announcing before committing, could
+    // announce a match that was never recorded). Throws if the match could not be recorded (so
+    // the caller stops and the segment is retried later); announcement failures are contained
+    // per chat since by then the cursor has already advanced.
+    private async finalizeSegment(steamId: string, segment: MatchSegment, expectedCursor: number): Promise<void> {
         const tgUserId = segment.user_id;
         const entries: { chatId: number; entry: GameHistoryEntry }[] = [];
 
-            if (segment.max_score) {
+        if (segment.max_score) {
             const coPlayers = await this.findSegmentCoPlayers(steamId, segment);
             const chats = await this.userDao.getUserChats(tgUserId);
             for (const chatId of chats) {
@@ -670,7 +683,7 @@ class SteamService {
             for (const { entry } of entries) {
                 ids.push(await this.gameHistoryDao.addGameHistoryEntry(entry, conn));
             }
-            await this.presenceEventDao.advanceCursor(conn, steamId, segment.lastEventId);
+            await this.presenceEventDao.advanceCursor(conn, steamId, expectedCursor, segment.lastEventId);
             return ids;
         });
 

--- a/acceptance/docker-compose.yml
+++ b/acceptance/docker-compose.yml
@@ -52,9 +52,11 @@ services:
       STEAM_PASSWORD: testpass
       STEAM_ADMIN_TELEGRAM_USER_ID: "9999"
       STEAM_CONTROL_PORT: "9100"
-      # Finalise idle matches quickly so acceptance tests don't wait minutes.
+      # Finalise idle matches (and confirm score resets) quickly so acceptance tests
+      # don't wait minutes.
       MATCH_IDLE_MS: "6000"
       MATCH_SWEEP_MS: "1000"
+      MATCH_RESET_CONFIRM_MS: "2000"
       GITHUB_API_BASE_URL: http://github-mock:8082
       GITHUB_REPO: acceptance/repo
       GITHUB_POLL_INTERVAL_MS: "1000"

--- a/acceptance/features/game_history.feature
+++ b/acceptance/features/game_history.feature
@@ -172,3 +172,40 @@ Feature: CS2 game history
     And Steam reports user "76561198000000980" stopped playing
     And 8 seconds pass
     Then chat 2111 has received 2 Steam messages containing "won a game"
+
+  Scenario: a flaky score dip does not split a match
+    # A glitched/out-of-order presence tick briefly reporting a low score must not split one
+    # real match into two. A reset only becomes a boundary once confirmed — by a further score
+    # in the new low range or by standing uncontradicted — so a dip that returns to the old
+    # range is folded away as noise and the match stays whole.
+    Given a chat with id 2112
+    And a user with id 5990 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000990"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000990"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000990" playing CS2 with score "5-3" on map "Inferno"
+    And Steam reports user "76561198000000990" playing CS2 with score "1-0" on map "Inferno"
+    And Steam reports user "76561198000000990" playing CS2 with score "8-3" on map "Inferno"
+    And Steam reports user "76561198000000990" stopped playing
+    Then chat 2112 eventually receives a new Steam message containing "won a game"
+    When 8 seconds pass
+    Then chat 2112 has received 1 Steam messages containing "won a game"
+    When the user sends "/game_history"
+    Then the bot reply contains "8-3"
+
+  Scenario: a real new match is confirmed by its next score without waiting out the window
+    # The counterpart to the flaky-dip scenario: when the low score is followed by another
+    # score in the same new range, that's a real new match — the old one is finalised right
+    # away rather than after the confirmation window.
+    Given a chat with id 2113
+    And a user with id 5991 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000991"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000991"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000991" playing CS2 with score "14-16" on map "Mirage"
+    And a moment passes
+    And Steam reports user "76561198000000991" playing CS2 with score "1-0" on map "Mirage"
+    And Steam reports user "76561198000000991" playing CS2 with score "2-0" on map "Mirage"
+    Then chat 2113 eventually receives a new Steam message containing "lost a game"
+    When the user sends "/game_history"
+    Then the bot reply contains "14-16"

--- a/acceptance/features/steps/helpers.py
+++ b/acceptance/features/steps/helpers.py
@@ -27,7 +27,7 @@ _APP_TABLES: List[str] = [
     "telegram_user", "user_settings", "user_steam_id", "user_chat", "chat_settings",
     "rollcall_player", "rsvp_list", "rsvp_entry", "rsvp_message", "rollcall_schedule",
     "github_state", "game_update", "steam_storage",
-    "current_match_coplayer", "current_match", "game_history_coplayer", "game_history",
+    "presence_event", "match_stream_cursor", "game_history_coplayer", "game_history",
 ]
 
 # How long to wait for the bot to poll an update and produce a reply.

--- a/dao/Database.ts
+++ b/dao/Database.ts
@@ -62,23 +62,18 @@ const splitStatements = (sql: string): string[] =>
         .map(stmt => stmt.trim())
         .filter(stmt => stmt.length > 0);
 
-// One-off, idempotent migration: current_match(+_coplayer) were originally keyed by
-// (chat_id,user_id) and are now keyed by (chat_id,steam_id). They hold only transient
-// in-flight match state, so when the old shape is detected (table exists without a steam_id
-// column) we drop them and let the CREATE TABLE statements below rebuild them. Runs once —
-// after the rebuild the steam_id column exists, so the guard is false on later startups.
-const migrateLegacyCurrentMatch = async (conn: PoolConnection): Promise<void> => {
+// One-off, idempotent migration: match detection used to keep mutable in-flight state in
+// current_match(+_coplayer); matches are now derived from the append-only presence_event log,
+// so those tables are gone entirely. They held only transient state, so dropping them loses
+// nothing durable — at worst a match in flight during the upgrade starts tracking from its
+// next presence tick.
+const migrateDropCurrentMatch = async (conn: PoolConnection): Promise<void> => {
     const [rows] = await conn.query<RowDataPacket[]>(
-        'SELECT ' +
-        "(SELECT COUNT(*) FROM information_schema.TABLES " +
-        " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'current_match') AS tbl, " +
-        "(SELECT COUNT(*) FROM information_schema.COLUMNS " +
-        " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'current_match' AND COLUMN_NAME = 'steam_id') AS col"
+        'SELECT COUNT(*) AS tbl FROM information_schema.TABLES ' +
+        " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'current_match'"
     );
-    const tableExists = Number(rows[0]?.tbl) > 0;
-    const hasSteamId = Number(rows[0]?.col) > 0;
-    if (tableExists && !hasSteamId) {
-        console.log('Rebuilding legacy current_match tables for per-Steam-account match keying.');
+    if (Number(rows[0]?.tbl) > 0) {
+        console.log('Dropping legacy current_match tables (match state now derives from presence_event).');
         await conn.query('DROP TABLE IF EXISTS current_match_coplayer');
         await conn.query('DROP TABLE IF EXISTS current_match');
     }
@@ -120,7 +115,7 @@ export const ensureSchema = async (): Promise<void> => {
     const ddl = readFileSync(join(import.meta.dirname, 'schema.sql'), 'utf-8');
     const conn = await getPool().getConnection();
     try {
-        await migrateLegacyCurrentMatch(conn);
+        await migrateDropCurrentMatch(conn);
         await migrateGameHistoryAnnouncementColumns(conn);
         for (const statement of splitStatements(ddl)) {
             await conn.query(statement);

--- a/dao/GameHistoryDAO.ts
+++ b/dao/GameHistoryDAO.ts
@@ -1,4 +1,4 @@
-import { ResultSetHeader, RowDataPacket } from 'mysql2/promise';
+import { PoolConnection, ResultSetHeader, RowDataPacket } from 'mysql2/promise';
 import { query, withTransaction } from './Database.js';
 import { ensureTelegramUser } from './telegramUser.js';
 
@@ -29,25 +29,6 @@ export interface SiblingMatch {
     score?: string;
     message_id: number | null;
     co_players: GameHistoryCoPlayer[];
-}
-
-// The match a Steam account is currently playing, surfaced in a chat. Keyed by
-// (chat,steam_id) — a match belongs to one Steam account and can't continue on another, so a
-// user's linked accounts each get their own row. user_id is carried for history attribution
-// and the end-of-game notification. Persisted so it survives session closes, game relaunches
-// mid-match, and bot restarts.
-export interface CurrentMatch {
-    chat_id: number;
-    steam_id: string;
-    user_id: number;
-    map?: string;
-    mode?: string;
-    max_score?: string;       // raw, highest score seen this match
-    player_name?: string;     // Steam display name, fallback for the notification
-    co_players: GameHistoryCoPlayer[];
-    started_at: Date;
-    last_progress_at: Date;
-    playing: boolean;
 }
 
 class GameHistoryDAO {
@@ -98,9 +79,11 @@ class GameHistoryDAO {
     }
 
     // Insert a finished match (and its co-players); returns the new game_history id so the caller
-    // can later attach the id of the grouped end-of-game announcement.
-    addGameHistoryEntry(entry: GameHistoryEntry): Promise<number> {
-        return withTransaction(async conn => {
+    // can later attach the id of the grouped end-of-game announcement. When a connection is
+    // passed, the insert joins that caller-managed transaction (used to commit history rows and
+    // the stream's finalisation cursor together); otherwise it runs in its own.
+    addGameHistoryEntry(entry: GameHistoryEntry, existingConn?: PoolConnection): Promise<number> {
+        const insert = async (conn: PoolConnection): Promise<number> => {
             await ensureTelegramUser(conn, entry.user_id);
             const [res] = await conn.query<ResultSetHeader>(
                 'INSERT INTO game_history (chat_id, user_id, player_name, mode, map, score, started_at, ended_at) ' +
@@ -125,7 +108,8 @@ class GameHistoryDAO {
                 );
             }
             return historyId;
-        });
+        };
+        return existingConn ? insert(existingConn) : withTransaction(insert);
     }
 
     // Recently-finished matches in a chat on a given map+mode, each with its co-players and the id
@@ -175,97 +159,6 @@ class GameHistoryDAO {
         ).then(() => undefined);
     }
 
-    private async _loadCurrentMatchCoPlayers(chat_id: number, steam_id: string): Promise<GameHistoryCoPlayer[]> {
-        const rows = await query<RowDataPacket[]>(
-            'SELECT co_user_id, name FROM current_match_coplayer WHERE chat_id = :chat_id AND steam_id = :steam_id',
-            { chat_id, steam_id }
-        );
-        return rows.map(r => ({ tg_user_id: Number(r.co_user_id), name: r.name ?? String(r.co_user_id) }));
-    }
-
-    private _matchFromRow(row: RowDataPacket, coPlayers: GameHistoryCoPlayer[]): CurrentMatch {
-        return {
-            chat_id: Number(row.chat_id),
-            steam_id: String(row.steam_id),
-            user_id: Number(row.user_id),
-            map: row.map ?? undefined,
-            mode: row.mode ?? undefined,
-            max_score: row.max_score ?? undefined,
-            player_name: row.player_name ?? undefined,
-            co_players: coPlayers,
-            started_at: row.started_at,
-            last_progress_at: row.last_progress_at,
-            playing: !!row.playing
-        };
-    }
-
-    async getCurrentMatch(chat_id: number, steam_id: string): Promise<CurrentMatch | null> {
-        const rows = await query<RowDataPacket[]>(
-            'SELECT chat_id, steam_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing ' +
-            'FROM current_match WHERE chat_id = :chat_id AND steam_id = :steam_id',
-            { chat_id, steam_id }
-        );
-        if (rows.length === 0) {
-            return null;
-        }
-        const coPlayers = await this._loadCurrentMatchCoPlayers(chat_id, steam_id);
-        return this._matchFromRow(rows[0], coPlayers);
-    }
-
-    setCurrentMatch(match: CurrentMatch): Promise<void> {
-        return withTransaction(async conn => {
-            await ensureTelegramUser(conn, match.user_id);
-            // Replace the row (cascades co-players away), then re-insert it and the co-players.
-            await conn.query('DELETE FROM current_match WHERE chat_id = :chat_id AND steam_id = :steam_id',
-                { chat_id: match.chat_id, steam_id: match.steam_id });
-            await conn.query(
-                'INSERT INTO current_match (chat_id, steam_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing) ' +
-                'VALUES (:chat_id, :steam_id, :user_id, :map, :mode, :max_score, :player_name, :started_at, :last_progress_at, :playing)',
-                {
-                    chat_id: match.chat_id,
-                    steam_id: match.steam_id,
-                    user_id: match.user_id,
-                    map: match.map ?? null,
-                    mode: match.mode ?? null,
-                    max_score: match.max_score ?? null,
-                    player_name: match.player_name ?? null,
-                    started_at: match.started_at,
-                    last_progress_at: match.last_progress_at,
-                    playing: match.playing ? 1 : 0
-                }
-            );
-            for (const co of match.co_players) {
-                await conn.query(
-                    'INSERT INTO current_match_coplayer (chat_id, steam_id, co_user_id, name) ' +
-                    'VALUES (:chat_id, :steam_id, :co_user_id, :name)',
-                    { chat_id: match.chat_id, steam_id: match.steam_id, co_user_id: co.tg_user_id, name: co.name ?? null }
-                );
-            }
-        });
-    }
-
-    deleteCurrentMatch(chat_id: number, steam_id: string): Promise<void> {
-        return query<ResultSetHeader>(
-            'DELETE FROM current_match WHERE chat_id = :chat_id AND steam_id = :steam_id',
-            { chat_id, steam_id }
-        ).then(() => undefined);
-    }
-
-    // Matches that are no longer playing and have not progressed since the cutoff. Used by the
-    // periodic sweep to finalise the trailing match of a play session (it has no following reset).
-    async getIdleMatches(cutoff: Date): Promise<CurrentMatch[]> {
-        const rows = await query<RowDataPacket[]>(
-            'SELECT chat_id, steam_id, user_id, map, mode, max_score, player_name, started_at, last_progress_at, playing ' +
-            'FROM current_match WHERE playing = 0 AND last_progress_at < :cutoff',
-            { cutoff }
-        );
-        const matches: CurrentMatch[] = [];
-        for (const row of rows) {
-            const coPlayers = await this._loadCurrentMatchCoPlayers(Number(row.chat_id), String(row.steam_id));
-            matches.push(this._matchFromRow(row, coPlayers));
-        }
-        return matches;
-    }
 }
 
 export default GameHistoryDAO;

--- a/dao/PresenceEventDAO.ts
+++ b/dao/PresenceEventDAO.ts
@@ -1,0 +1,130 @@
+import { PoolConnection, ResultSetHeader, RowDataPacket } from 'mysql2/promise';
+import { query } from './Database.js';
+import { PresenceEvent } from '../matchDerivation.js';
+
+// Data access for the append-only presence_event log and the per-stream finalisation cursor.
+// The log is the source of truth for match detection (see matchDerivation.ts); the cursor
+// records how far each stream has been folded into game_history so re-derivation is
+// idempotent. All match semantics live in the derivation module — this class only stores
+// and retrieves events.
+class PresenceEventDAO {
+    private _eventFromRow(row: RowDataPacket): PresenceEvent {
+        return {
+            id: Number(row.id),
+            steam_id: String(row.steam_id),
+            user_id: Number(row.user_id),
+            playing: !!row.playing,
+            map: row.map ?? undefined,
+            mode: row.mode ?? undefined,
+            raw_score: row.raw_score ?? undefined,
+            score_total: row.score_total ?? null,
+            player_name: row.player_name ?? undefined,
+            created_at: row.created_at
+        };
+    }
+
+    async appendEvent(event: Omit<PresenceEvent, 'id'>): Promise<number> {
+        const res = await query<ResultSetHeader>(
+            'INSERT INTO presence_event (steam_id, user_id, playing, map, mode, raw_score, score_total, player_name, created_at) ' +
+            'VALUES (:steam_id, :user_id, :playing, :map, :mode, :raw_score, :score_total, :player_name, :created_at)',
+            {
+                steam_id: event.steam_id,
+                user_id: event.user_id,
+                playing: event.playing ? 1 : 0,
+                map: event.map ?? null,
+                mode: event.mode ?? null,
+                raw_score: event.raw_score ?? null,
+                score_total: event.score_total ?? null,
+                player_name: event.player_name ?? null,
+                created_at: event.created_at
+            }
+        );
+        return res.insertId;
+    }
+
+    // The stream's newest event, used to detect whether an incoming snapshot is a transition
+    // worth recording or a repeat to drop.
+    async getLastEvent(steam_id: string): Promise<PresenceEvent | null> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT id, steam_id, user_id, playing, map, mode, raw_score, score_total, player_name, created_at ' +
+            'FROM presence_event WHERE steam_id = :steam_id ORDER BY id DESC LIMIT 1',
+            { steam_id }
+        );
+        return rows.length ? this._eventFromRow(rows[0]) : null;
+    }
+
+    // The unfinalised tail of a stream: everything past the cursor, in order. This is the
+    // window match derivation replays.
+    async getEventsAfter(steam_id: string, afterId: number): Promise<PresenceEvent[]> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT id, steam_id, user_id, playing, map, mode, raw_score, score_total, player_name, created_at ' +
+            'FROM presence_event WHERE steam_id = :steam_id AND id > :afterId ORDER BY id ASC',
+            { steam_id, afterId }
+        );
+        return rows.map(r => this._eventFromRow(r));
+    }
+
+    // For reconstructing another account's state across a match's time range: its last event
+    // before the range (its state as the match began) plus its events within the range.
+    async getStreamAround(steam_id: string, from: Date, to: Date): Promise<PresenceEvent[]> {
+        const rows = await query<RowDataPacket[]>(
+            '(SELECT id, steam_id, user_id, playing, map, mode, raw_score, score_total, player_name, created_at ' +
+            ' FROM presence_event WHERE steam_id = :steam_id AND created_at < :from ORDER BY id DESC LIMIT 1) ' +
+            'UNION ALL ' +
+            '(SELECT id, steam_id, user_id, playing, map, mode, raw_score, score_total, player_name, created_at ' +
+            ' FROM presence_event WHERE steam_id = :steam_id AND created_at >= :from AND created_at <= :to) ' +
+            'ORDER BY id ASC',
+            { steam_id, from, to }
+        );
+        return rows.map(r => this._eventFromRow(r));
+    }
+
+    async getTrackedSteamIds(): Promise<string[]> {
+        const rows = await query<RowDataPacket[]>('SELECT DISTINCT steam_id FROM presence_event');
+        return rows.map(r => String(r.steam_id));
+    }
+
+    async getCursor(steam_id: string): Promise<number> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT finalized_event_id FROM match_stream_cursor WHERE steam_id = :steam_id',
+            { steam_id }
+        );
+        return rows.length ? Number(rows[0].finalized_event_id) : 0;
+    }
+
+    // Advance the cursor past a finalised segment. Runs on the caller's transaction so it
+    // commits (or rolls back) together with the game_history insert — that atomicity is what
+    // guarantees a match is announced exactly once.
+    async advanceCursor(conn: PoolConnection, steam_id: string, eventId: number): Promise<void> {
+        await conn.query(
+            'INSERT INTO match_stream_cursor (steam_id, finalized_event_id) VALUES (:steam_id, :eventId) ' +
+            'ON DUPLICATE KEY UPDATE finalized_event_id = GREATEST(finalized_event_id, VALUES(finalized_event_id))',
+            { steam_id, eventId }
+        );
+    }
+
+    // Streams with events past their cursor — the sweep's candidates for idle finalisation
+    // and reset time-confirmation.
+    async getStreamsWithUnfinalizedEvents(): Promise<string[]> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT e.steam_id FROM presence_event e ' +
+            'LEFT JOIN match_stream_cursor c ON c.steam_id = e.steam_id ' +
+            'GROUP BY e.steam_id, c.finalized_event_id ' +
+            'HAVING MAX(e.id) > COALESCE(c.finalized_event_id, 0)'
+        );
+        return rows.map(r => String(r.steam_id));
+    }
+
+    // Drop old, already-finalised events. Never touches events past a stream's cursor, so a
+    // long-idle unfinalised tail survives any TTL.
+    async prune(cutoff: Date): Promise<void> {
+        await query<ResultSetHeader>(
+            'DELETE e FROM presence_event e ' +
+            'LEFT JOIN match_stream_cursor c ON c.steam_id = e.steam_id ' +
+            'WHERE e.created_at < :cutoff AND e.id <= COALESCE(c.finalized_event_id, 0)',
+            { cutoff }
+        );
+    }
+}
+
+export default PresenceEventDAO;

--- a/dao/PresenceEventDAO.ts
+++ b/dao/PresenceEventDAO.ts
@@ -92,15 +92,35 @@ class PresenceEventDAO {
         return rows.length ? Number(rows[0].finalized_event_id) : 0;
     }
 
-    // Advance the cursor past a finalised segment. Runs on the caller's transaction so it
-    // commits (or rolls back) together with the game_history insert — that atomicity is what
-    // guarantees a match is announced exactly once.
-    async advanceCursor(conn: PoolConnection, steam_id: string, eventId: number): Promise<void> {
-        await conn.query(
-            'INSERT INTO match_stream_cursor (steam_id, finalized_event_id) VALUES (:steam_id, :eventId) ' +
-            'ON DUPLICATE KEY UPDATE finalized_event_id = GREATEST(finalized_event_id, VALUES(finalized_event_id))',
-            { steam_id, eventId }
+    // Advance the cursor past a finalised segment, compare-and-swap style: the write only
+    // succeeds if the cursor still holds the value the derivation started from. Runs on the
+    // caller's transaction so it commits (or rolls back) together with the game_history
+    // inserts — that atomicity is what guarantees a match is recorded exactly once, and the
+    // CAS makes a concurrent finaliser (e.g. an overlapping deploy running a second bot
+    // instance against the same database) fail loudly instead of double-recording.
+    async advanceCursor(conn: PoolConnection, steam_id: string, expectedEventId: number, eventId: number): Promise<void> {
+        if (expectedEventId === 0) {
+            try {
+                await conn.query(
+                    'INSERT INTO match_stream_cursor (steam_id, finalized_event_id) VALUES (:steam_id, :eventId)',
+                    { steam_id, eventId }
+                );
+            } catch (err: any) {
+                if (err && err.code === 'ER_DUP_ENTRY') {
+                    throw new Error(`Cursor for stream ${steam_id} was created by a concurrent finaliser`);
+                }
+                throw err;
+            }
+            return;
+        }
+        const [res] = await conn.query<ResultSetHeader>(
+            'UPDATE match_stream_cursor SET finalized_event_id = :eventId ' +
+            'WHERE steam_id = :steam_id AND finalized_event_id = :expectedEventId',
+            { steam_id, eventId, expectedEventId }
         );
+        if (res.affectedRows === 0) {
+            throw new Error(`Cursor for stream ${steam_id} moved past ${expectedEventId} under a concurrent finaliser`);
+        }
     }
 
     // Streams with events past their cursor — the sweep's candidates for idle finalisation
@@ -115,13 +135,22 @@ class PresenceEventDAO {
         return rows.map(r => String(r.steam_id));
     }
 
-    // Drop old, already-finalised events. Never touches events past a stream's cursor, so a
-    // long-idle unfinalised tail survives any TTL.
+    // Drop old, already-finalised events. Never touches events past a live stream's cursor, so
+    // a long-idle unfinalised tail survives the TTL as long as the stream shows any life. Dead
+    // streams — no event at all since the cutoff, e.g. an account unregistered while its last
+    // observation was still "playing", which can never finalise — are dropped wholesale so they
+    // don't occupy the sweep and the log forever.
     async prune(cutoff: Date): Promise<void> {
         await query<ResultSetHeader>(
             'DELETE e FROM presence_event e ' +
             'LEFT JOIN match_stream_cursor c ON c.steam_id = e.steam_id ' +
             'WHERE e.created_at < :cutoff AND e.id <= COALESCE(c.finalized_event_id, 0)',
+            { cutoff }
+        );
+        await query<ResultSetHeader>(
+            'DELETE e FROM presence_event e ' +
+            'JOIN (SELECT steam_id FROM presence_event GROUP BY steam_id HAVING MAX(created_at) < :cutoff) dead ' +
+            '  ON dead.steam_id = e.steam_id',
             { cutoff }
         );
     }

--- a/dao/schema.sql
+++ b/dao/schema.sql
@@ -132,41 +132,39 @@ CREATE TABLE IF NOT EXISTS steam_storage (
     PRIMARY KEY (filename)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- The match a Steam account is currently playing, surfaced in a given chat. Keyed by
--- (chat,steam_id) — NOT by user — because a match belongs to one Steam account and cannot
--- continue on another; a user with several linked accounts gets one row per account, so a
--- stop on one account never disturbs another's match. user_id is carried for history
--- attribution and the end-of-game notification. One row per (chat,steam_id); replaced on
--- write. Survives session closes and bot restarts so a match can span a game relaunch. A
--- match is finished (and moved to game_history) on a score reset / map / mode change, or
--- once it has been idle (not playing, no score progress) past the idle window.
-CREATE TABLE IF NOT EXISTS current_match (
-    chat_id          BIGINT       NOT NULL,
-    steam_id         VARCHAR(32)  NOT NULL,
-    user_id          BIGINT       NOT NULL,
-    map              VARCHAR(64)  NULL,
-    mode             VARCHAR(255) NULL,
-    max_score        VARCHAR(64)  NULL,
-    player_name      VARCHAR(255) NULL,
-    started_at       DATETIME(3)  NOT NULL,
-    last_progress_at DATETIME(3)  NOT NULL,
-    playing          TINYINT(1)   NOT NULL,
-    PRIMARY KEY (chat_id, steam_id),
-    KEY idx_current_match_idle (playing, last_progress_at),
-    CONSTRAINT fk_current_match_user FOREIGN KEY (user_id)
-        REFERENCES telegram_user (user_id) ON DELETE CASCADE
+-- Append-only log of a tracked Steam account's CS2 presence, one row per *transition*
+-- (started/stopped playing, map/mode change, score change; identical consecutive snapshots
+-- are deduplicated on write). This is the source of truth for match detection: matches are
+-- derived retrospectively by segmenting a stream (matchDerivation.ts) rather than by
+-- mutating a single current-state row, so one flaky tick can't irreversibly split or merge
+-- a match. Keyed per Steam account — the observed fact is account-level; chats only come in
+-- when a finished match is fanned out to game_history/announcements. user_id carries the
+-- steam→telegram mapping at observation time; no FK so the hot-path append never has to
+-- ensure a telegram_user row. Pruned past a TTL, but never past a stream's cursor.
+CREATE TABLE IF NOT EXISTS presence_event (
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    steam_id    VARCHAR(32)  NOT NULL,
+    user_id     BIGINT       NOT NULL,
+    playing     TINYINT(1)   NOT NULL,
+    map         VARCHAR(64)  NULL,
+    mode        VARCHAR(255) NULL,
+    raw_score   VARCHAR(64)  NULL,
+    score_total INT          NULL,
+    player_name VARCHAR(255) NULL,
+    created_at  DATETIME(3)  NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_presence_event_stream (steam_id, id),
+    KEY idx_presence_event_prune (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- Other tracked players seen in the same in-progress match. name is a point-in-time
--- snapshot; co_user_id carries no FK so a co-player needn't be ensured every tick.
-CREATE TABLE IF NOT EXISTS current_match_coplayer (
-    chat_id    BIGINT       NOT NULL,
-    steam_id   VARCHAR(32)  NOT NULL,
-    co_user_id BIGINT       NOT NULL,
-    name       VARCHAR(255) NULL,
-    PRIMARY KEY (chat_id, steam_id, co_user_id),
-    CONSTRAINT fk_cmcp_match FOREIGN KEY (chat_id, steam_id)
-        REFERENCES current_match (chat_id, steam_id) ON DELETE CASCADE
+-- How far each stream has been finalised: events at or before finalized_event_id have been
+-- folded into game_history (and announced). Derivation only replays events past the cursor,
+-- and the cursor advances in the same transaction as the history insert, which is what makes
+-- finalisation idempotent — re-deriving a stream can never announce the same match twice.
+CREATE TABLE IF NOT EXISTS match_stream_cursor (
+    steam_id           VARCHAR(32) NOT NULL,
+    finalized_event_id BIGINT      NOT NULL,
+    PRIMARY KEY (steam_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- A finished match. score is the raw "16-14" (player-opponent); win/loss/tie is derived

--- a/dao/schema.sql
+++ b/dao/schema.sql
@@ -158,9 +158,11 @@ CREATE TABLE IF NOT EXISTS presence_event (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- How far each stream has been finalised: events at or before finalized_event_id have been
--- folded into game_history (and announced). Derivation only replays events past the cursor,
--- and the cursor advances in the same transaction as the history insert, which is what makes
--- finalisation idempotent — re-deriving a stream can never announce the same match twice.
+-- folded into game_history. Derivation only replays events past the cursor, and the cursor
+-- advances (compare-and-swap) in the same transaction as the history insert, which is what
+-- makes finalisation idempotent — re-deriving a stream can never record the same match twice,
+-- even from a concurrent finaliser. The announcement itself is sent after that commit, so it
+-- is at-most-once per finalisation rather than exactly-once.
 CREATE TABLE IF NOT EXISTS match_stream_cursor (
     steam_id           VARCHAR(32) NOT NULL,
     finalized_event_id BIGINT      NOT NULL,

--- a/matchDerivation.ts
+++ b/matchDerivation.ts
@@ -1,0 +1,266 @@
+// Pure derivation of CS2 matches from a per-Steam-account presence event log.
+//
+// The bot appends one row to the presence_event table per *transition* in a tracked account's
+// presence (started/stopped playing, map/mode change, score change). This module turns such a
+// stream back into matches: it segments the events at match boundaries, decides which segments
+// are finished, and reconstructs co-players by comparing streams. It is deliberately free of
+// I/O and clocks — `now` is a parameter — so the boundary rules are unit-testable and a stream
+// can be re-derived at any time with identical results.
+
+export interface PresenceEvent {
+    id: number;
+    steam_id: string;
+    user_id: number;
+    playing: boolean;
+    map?: string;
+    mode?: string;
+    raw_score?: string;
+    score_total?: number | null;
+    player_name?: string;
+    created_at: Date;
+}
+
+export interface DerivationConfig {
+    // Score-total drop (beyond rounds lost to e.g. presence flakiness) that signals a new match.
+    resetTolerance: number;
+    // How long a stopped, progress-less trailing match waits before it is considered finished.
+    matchIdleMs: number;
+    // How long an uncontradicted score reset must stand before it becomes a boundary. A dip that
+    // returns to the old range within this window (or before any further scored event) is folded
+    // away as a flake instead of splitting the match.
+    resetConfirmMs: number;
+}
+
+// One reconstructed match: a run of events between boundaries, projected to the fields the
+// history/announcement layer consumes.
+export interface MatchSegment {
+    user_id: number;           // latest steam→telegram mapping seen in the segment
+    map?: string;              // first non-null map seen
+    mode?: string;             // first non-null mode seen
+    max_score?: string;        // raw score of the highest-total event seen
+    player_name?: string;      // latest non-null Steam display name
+    started_at: Date;
+    last_event_at: Date;
+    playing: boolean;          // last event's flag
+    lastEventId: number;       // cursor position once this segment is finalised
+    events: PresenceEvent[];
+}
+
+export interface StreamDerivation {
+    closed: MatchSegment[];    // finished matches, oldest first
+    open: MatchSegment | null; // the still-live segment, if any
+}
+
+// Parse a raw "16-14" (or "16:14") score into its parts and round total.
+export const parseRawScore = (score?: string): { a: number; b: number; total: number } | null => {
+    if (!score) return null;
+    const m = score.replace(/[\[\]]/g, '').trim().match(/^(\d+)\s*[-:]\s*(\d+)$/);
+    if (!m) return null;
+    const a = parseInt(m[1], 10);
+    const b = parseInt(m[2], 10);
+    return { a, b, total: a + b };
+};
+
+const maxTotal = (seg: MatchSegment): number | null => {
+    const parsed = parseRawScore(seg.max_score);
+    return parsed ? parsed.total : null;
+};
+
+const newSegment = (e: PresenceEvent): MatchSegment => ({
+    user_id: e.user_id,
+    map: e.map,
+    mode: e.mode,
+    max_score: e.raw_score,
+    player_name: e.player_name,
+    started_at: e.created_at,
+    last_event_at: e.created_at,
+    playing: e.playing,
+    lastEventId: e.id,
+    events: [e]
+});
+
+// Fold a continuation event into a segment: map/mode keep the first non-null value (matching the
+// old cur.map || map precedence), the max score only ever moves up, names/attribution track the
+// latest observation.
+const absorb = (seg: MatchSegment, e: PresenceEvent, countScore: boolean = true): void => {
+    if (e.map && !seg.map) seg.map = e.map;
+    if (e.mode && !seg.mode) seg.mode = e.mode;
+    if (countScore && e.score_total != null) {
+        const cur = maxTotal(seg);
+        if (cur == null || e.score_total > cur) {
+            seg.max_score = e.raw_score;
+        }
+    }
+    if (e.player_name) seg.player_name = e.player_name;
+    seg.user_id = e.user_id;
+    seg.playing = e.playing;
+    seg.last_event_at = e.created_at;
+    seg.lastEventId = e.id;
+    seg.events.push(e);
+};
+
+const mapChanged = (segMap: string | undefined, eMap: string | undefined): boolean =>
+    !!(eMap && segMap && eMap.toLowerCase() !== segMap.toLowerCase());
+
+const modeChanged = (segMode: string | undefined, eMode: string | undefined): boolean =>
+    !!(eMode && segMode && eMode !== segMode);
+
+// Segment a single account's event stream (ordered by id ascending) into matches.
+//
+// Boundary rules, relative to the accumulated segment state:
+//  - a different map or mode is a boundary immediately;
+//  - a score whose total drops more than resetTolerance below the segment max is a *provisional*
+//    boundary: it is confirmed by the next scored event staying in the new low range, or by
+//    standing uncontradicted for resetConfirmMs; a scored event back in the old range refutes it
+//    and the dip is absorbed as noise;
+//  - stopping the game is never a boundary (a relaunch resumes the match); it only starts the
+//    idle countdown. A stopped segment with no activity for matchIdleMs is closed.
+export const segmentStream = (events: PresenceEvent[], now: Date, config: DerivationConfig): StreamDerivation => {
+    const closed: MatchSegment[] = [];
+    let seg: MatchSegment | null = null;
+    // A provisional post-reset segment, kept aside until the reset is confirmed or refuted.
+    let pending: MatchSegment | null = null;
+
+    for (const e of events) {
+        // Re-process the event against the segment state until it has been absorbed somewhere:
+        // confirming a pending reset changes what "the current segment" is, and the event that
+        // triggered the confirmation must then be re-evaluated against the new segment.
+        let toProcess: PresenceEvent | null = e;
+        while (toProcess) {
+            const ev = toProcess;
+            toProcess = null;
+
+            if (!seg) {
+                seg = newSegment(ev);
+                continue;
+            }
+
+            if (pending) {
+                if (ev.score_total != null) {
+                    const oldMax = maxTotal(seg);
+                    const backInOldRange = oldMax != null && ev.score_total >= oldMax - config.resetTolerance;
+                    const vsSegMap = mapChanged(seg.map, ev.map);
+                    const vsSegMode = modeChanged(seg.mode, ev.mode);
+                    if (backInOldRange && !vsSegMap && !vsSegMode) {
+                        // The dip was a flake: fold its events back without letting their scores
+                        // drag the max around, and continue the original match.
+                        for (const pe of pending.events) absorb(seg, pe, false);
+                        pending = null;
+                        absorb(seg, ev);
+                    } else {
+                        // Still in the new low range (or the map/mode moved on): the reset was
+                        // real. The old match ends where it stood; the dip started the new one.
+                        closed.push(seg);
+                        seg = pending;
+                        pending = null;
+                        toProcess = ev;
+                    }
+                } else if (mapChanged(pending.map, ev.map) || modeChanged(pending.mode, ev.mode)) {
+                    // The nascent segment itself hit a hard boundary: that settles the reset too.
+                    closed.push(seg);
+                    seg = pending;
+                    pending = null;
+                    toProcess = ev;
+                } else {
+                    absorb(pending, ev);
+                }
+                continue;
+            }
+
+            if (mapChanged(seg.map, ev.map) || modeChanged(seg.mode, ev.mode)) {
+                closed.push(seg);
+                seg = newSegment(ev);
+                continue;
+            }
+
+            const segMax = maxTotal(seg);
+            const reset = ev.score_total != null && segMax != null && ev.score_total < segMax - config.resetTolerance;
+            if (reset) {
+                pending = newSegment(ev);
+                continue;
+            }
+
+            absorb(seg, ev);
+        }
+    }
+
+    // A trailing unresolved reset is confirmed by time alone: if it has stood uncontradicted for
+    // the confirmation window, the old match is over. Otherwise it stays provisional — the next
+    // derivation (more events, or more time) settles it.
+    if (seg && pending) {
+        if (now.getTime() - pending.started_at.getTime() >= config.resetConfirmMs) {
+            closed.push(seg);
+            seg = pending;
+            pending = null;
+        }
+    }
+
+    // Idle: a stopped trailing segment with no activity for the idle window is finished.
+    let open: MatchSegment | null = seg;
+    if (open && !pending && !open.playing && now.getTime() - open.last_event_at.getTime() >= config.matchIdleMs) {
+        closed.push(open);
+        open = null;
+    }
+
+    return { closed, open };
+};
+
+export interface CoPlayer {
+    user_id: number;
+    player_name?: string;  // their latest Steam display name around the match, as a fallback
+}
+
+// Reconstruct who was in the same match as `segment` by replaying the other tracked accounts'
+// streams: at each of the segment's observation points, another account is a co-player if its
+// state at that moment was in CS2 on a compatible map and mode with a score total within
+// tolerance — the same test the live version applied per tick, now answered retrospectively.
+// `otherStreams` maps steam_id → that account's events (ordered by id), and may include events
+// from before the segment so state-at-time is known; the segment's own account is skipped by
+// the caller. Accounts belonging to the segment's own user are skipped here.
+export const findCoPlayers = (
+    segment: MatchSegment,
+    otherStreams: Map<string, PresenceEvent[]>,
+    config: DerivationConfig
+): CoPlayer[] => {
+    const byUser = new Map<number, CoPlayer>();
+
+    for (const [, stream] of otherStreams) {
+        if (stream.length === 0) continue;
+
+        let idx = 0;
+        // Running view of the segment as it accumulated, so each point-in-time check uses what
+        // was known *then* (mirroring the old per-tick collection).
+        let runMap: string | undefined;
+        let runMode: string | undefined;
+        let runMax: number | null = null;
+
+        for (const e of segment.events) {
+            if (e.map && !runMap) runMap = e.map;
+            if (e.mode && !runMode) runMode = e.mode;
+            if (e.score_total != null && (runMax == null || e.score_total > runMax)) {
+                runMax = e.score_total;
+            }
+
+            // The other account's state at this moment = its last event at or before it.
+            while (idx + 1 < stream.length && stream[idx + 1].created_at.getTime() <= e.created_at.getTime()) {
+                idx++;
+            }
+            const o = stream[idx];
+            if (o.created_at.getTime() > e.created_at.getTime()) continue; // no state yet
+            if (o.user_id === segment.user_id) continue;                   // same user, other account
+            if (!o.playing) continue;
+            if (mapChanged(runMap, o.map)) continue;
+            if (modeChanged(runMode, o.mode)) continue;
+            if (runMax != null && o.score_total != null && Math.abs(runMax - o.score_total) > config.resetTolerance) continue;
+
+            const existing = byUser.get(o.user_id);
+            if (!existing) {
+                byUser.set(o.user_id, { user_id: o.user_id, player_name: o.player_name });
+            } else if (o.player_name) {
+                existing.player_name = o.player_name;
+            }
+        }
+    }
+
+    return Array.from(byUser.values());
+};

--- a/matchDerivation.ts
+++ b/matchDerivation.ts
@@ -4,8 +4,11 @@
 // presence (started/stopped playing, map/mode change, score change). This module turns such a
 // stream back into matches: it segments the events at match boundaries, decides which segments
 // are finished, and reconstructs co-players by comparing streams. It is deliberately free of
-// I/O and clocks — `now` is a parameter — so the boundary rules are unit-testable and a stream
-// can be re-derived at any time with identical results.
+// I/O and clocks — `now` is a parameter — so the boundary rules are unit-testable: derivation
+// is a pure function of (events, now). Note that `now` is a real input: a reset that is
+// confirmed by time (rather than by a later event) resolves differently before and after the
+// confirmation window, so incremental live derivation and a later batch replay can disagree
+// about a dip whose refutation arrived only after the window had already confirmed it.
 
 export interface PresenceEvent {
     id: number;
@@ -29,6 +32,11 @@ export interface DerivationConfig {
     // returns to the old range within this window (or before any further scored event) is folded
     // away as a flake instead of splitting the match.
     resetConfirmMs: number;
+    // How old another account's last observation may be and still count as its "state" for
+    // co-player matching. The live implementation this replaces compared current presence, which
+    // could not be days stale; without a bound, an account whose stop transition was missed
+    // (e.g. bot downtime) would look in-game until its events are pruned.
+    coPlayerStaleMs: number;
 }
 
 // One reconstructed match: a run of events between boundaries, projected to the fields the
@@ -161,7 +169,10 @@ export const segmentStream = (events: PresenceEvent[], now: Date, config: Deriva
                         pending = null;
                         toProcess = ev;
                     }
-                } else if (mapChanged(pending.map, ev.map) || modeChanged(pending.mode, ev.mode)) {
+                } else if (mapChanged(pending.map ?? seg.map, ev.map) || modeChanged(pending.mode ?? seg.mode, ev.mode)) {
+                    // Compared against the pending segment's map/mode, falling back to the outer
+                    // segment's when the dip event didn't carry the field — a conflicting
+                    // observation must open a boundary either way, not get folded away.
                     // The nascent segment itself hit a hard boundary: that settles the reset too.
                     closed.push(seg);
                     seg = pending;
@@ -255,6 +266,7 @@ export const findCoPlayers = (
             }
             const o = stream[idx];
             if (o.created_at.getTime() > e.created_at.getTime()) continue; // no state yet
+            if (e.created_at.getTime() - o.created_at.getTime() > config.coPlayerStaleMs) continue; // stale
             if (o.user_id === segment.user_id) continue;                   // same user, other account
             if (!o.playing) continue;
             if (mapChanged(runMap, o.map)) continue;

--- a/matchDerivation.ts
+++ b/matchDerivation.ts
@@ -41,6 +41,10 @@ export interface MatchSegment {
     player_name?: string;      // latest non-null Steam display name
     started_at: Date;
     last_event_at: Date;
+    // When the account was last seen in CS2. The idle countdown runs from here, not from the
+    // stop event — matching the old last_progress_at semantics, where stopping never counted
+    // as progress.
+    last_playing_at: Date;
     playing: boolean;          // last event's flag
     lastEventId: number;       // cursor position once this segment is finalised
     events: PresenceEvent[];
@@ -74,6 +78,7 @@ const newSegment = (e: PresenceEvent): MatchSegment => ({
     player_name: e.player_name,
     started_at: e.created_at,
     last_event_at: e.created_at,
+    last_playing_at: e.created_at,
     playing: e.playing,
     lastEventId: e.id,
     events: [e]
@@ -95,6 +100,7 @@ const absorb = (seg: MatchSegment, e: PresenceEvent, countScore: boolean = true)
     seg.user_id = e.user_id;
     seg.playing = e.playing;
     seg.last_event_at = e.created_at;
+    if (e.playing) seg.last_playing_at = e.created_at;
     seg.lastEventId = e.id;
     seg.events.push(e);
 };
@@ -195,9 +201,11 @@ export const segmentStream = (events: PresenceEvent[], now: Date, config: Deriva
         }
     }
 
-    // Idle: a stopped trailing segment with no activity for the idle window is finished.
+    // Idle: a stopped trailing segment whose account hasn't been seen in CS2 for the idle
+    // window is finished. The countdown runs from the last *playing* observation — stopping is
+    // not progress, so a stop right after the last score doesn't extend the match's life.
     let open: MatchSegment | null = seg;
-    if (open && !pending && !open.playing && now.getTime() - open.last_event_at.getTime() >= config.matchIdleMs) {
+    if (open && !pending && !open.playing && now.getTime() - open.last_playing_at.getTime() >= config.matchIdleMs) {
         closed.push(open);
         open = null;
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node --loader ts-node/esm main.ts",
     "build": "tsc && cp dao/schema.sql dist/dao/schema.sql",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --loader ts-node/esm --test test/*.test.ts"
   },
   "engines": {
     "node": ">=24"

--- a/test/matchDerivation.test.ts
+++ b/test/matchDerivation.test.ts
@@ -11,7 +11,8 @@ const at = (seconds: number): Date => new Date(T0 + seconds * 1000);
 const config: DerivationConfig = {
     resetTolerance: 2,
     matchIdleMs: 10 * 60 * 1000,
-    resetConfirmMs: 30 * 1000
+    resetConfirmMs: 30 * 1000,
+    coPlayerStaleMs: 15 * 60 * 1000
 };
 
 let nextId = 1;
@@ -307,4 +308,105 @@ test('a scoreless match is derivable but carries no score', () => {
     const { closed } = segmentStream(events, at(60 + 11 * 60), config);
     assert.equal(closed.length, 1);
     assert.equal(closed[0].max_score, undefined);
+});
+
+test('a multi-event dip (including a stop) folds back cleanly on refute', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '9-3' }),
+        ev(60, { map: 'Inferno', score: '1-0' }),  // flake dip → pending
+        ev(70, { playing: false }),                // absorbed into pending
+        ev(90, { map: 'Inferno', score: '10-3' })  // back in old range → refute
+    ];
+    const { closed, open } = segmentStream(events, at(120), config);
+    assert.equal(closed.length, 0);
+    assert.ok(open);
+    assert.equal(open!.max_score, '10-3');
+    assert.equal(open!.playing, true);
+    assert.equal(open!.lastEventId, 4);
+    // The folded events keep the segment's event list time-ordered.
+    const times = open!.events.map(e => e.created_at.getTime());
+    assert.deepEqual(times, [...times].sort((a, b) => a - b));
+    // last_playing_at reflects the refuting event, not the folded stop.
+    assert.equal(open!.last_playing_at.getTime(), at(90).getTime());
+});
+
+test('a map change while a reset is pending opens a boundary even if the dip carried no map', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', mode: 'Competitive', score: '16-13' }),
+        ev(60, { score: '1-0' }),                       // dip without map → pending
+        ev(70, { map: 'Mirage', mode: 'Competitive' })  // scoreless but conflicting map
+    ];
+    const { closed, open } = segmentStream(events, at(71), config);
+    // The conflicting map settles the reset: the old match closes. The mapless dip then reads
+    // as the start of the new Mirage match whose map key simply lagged a tick.
+    assert.equal(closed.length, 1);
+    assert.equal(closed[0].map, 'Inferno');
+    assert.equal(closed[0].max_score, '16-13');
+    assert.ok(open);
+    assert.equal(open!.map, 'Mirage');
+    assert.equal(open!.max_score, '1-0');
+});
+
+test('a score exactly at the tolerance boundary refutes a pending reset', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '5-3' }),   // total 8
+        ev(60, { map: 'Inferno', score: '1-0' }),  // dip → pending
+        ev(90, { map: 'Inferno', score: '4-2' })   // total 6 = 8 - tolerance → still old range
+    ];
+    const { closed, open } = segmentStream(events, at(600), config);
+    assert.equal(closed.length, 0);
+    assert.ok(open);
+    assert.equal(open!.max_score, '5-3');
+});
+
+test('time confirmation and idle close resolve in the same derivation, with correct cursor ids', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Mirage', score: '14-16' }),  // id 1
+        ev(60, { map: 'Mirage', score: '1-0' }),   // id 2: dip → pending
+        ev(70, { playing: false })                 // id 3: absorbed into pending
+    ];
+    const { closed, open } = segmentStream(events, at(70 + 11 * 60), config);
+    // The old match closes by time-confirmed reset; the dip stub then closes by idle.
+    assert.equal(closed.length, 2);
+    assert.equal(closed[0].max_score, '14-16');
+    assert.equal(closed[0].lastEventId, 1);  // the dip events stay past the first cursor advance
+    assert.equal(closed[1].max_score, '1-0');
+    assert.equal(closed[1].lastEventId, 3);
+    assert.equal(open, null);
+});
+
+test('two consecutive confirmed resets produce three matches', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '13-5' }),
+        ev(60, { map: 'Inferno', score: '1-0' }),
+        ev(90, { map: 'Inferno', score: '13-2' }),   // confirms reset 1, continues match 2
+        ev(150, { map: 'Inferno', score: '0-1' }),
+        ev(180, { map: 'Inferno', score: '1-1' })    // confirms reset 2
+    ];
+    const { closed, open } = segmentStream(events, at(181), config);
+    assert.equal(closed.length, 2);
+    assert.equal(closed[0].max_score, '13-5');
+    assert.equal(closed[1].max_score, '13-2');
+    assert.ok(open);
+    assert.equal(open!.max_score, '1-1');
+});
+
+test('co-player: an observation older than the staleness bound does not count', () => {
+    nextId = 1;
+    const seg = segmentStream([
+        ev(0, { map: 'Inferno', mode: 'Competitive', score: '5-3' }),
+        ev(60, { map: 'Inferno', mode: 'Competitive', score: '6-3' })
+    ], at(61), config).open!;
+
+    nextId = 100;
+    const stale: PresenceEvent[] = [
+        { ...ev(-16 * 60, { map: 'Inferno', mode: 'Competitive', score: '5-3', user: 220 }), steam_id: 'B' }
+    ];
+    const cos = findCoPlayers(seg, new Map([['B', stale]]), config);
+    assert.equal(cos.length, 0);
 });

--- a/test/matchDerivation.test.ts
+++ b/test/matchDerivation.test.ts
@@ -52,26 +52,32 @@ test('a stopped match closes after the idle window, not before', () => {
         ev(0, { map: 'Inferno', score: '16-14' }),
         ev(60, { playing: false })
     ];
-    const before = segmentStream(events, at(60 + 9 * 60), config);
+    const before = segmentStream(events, at(9 * 60), config);
     assert.equal(before.closed.length, 0);
     assert.ok(before.open);
 
-    const after = segmentStream(events, at(60 + 11 * 60), config);
+    const after = segmentStream(events, at(11 * 60), config);
     assert.equal(after.closed.length, 1);
     assert.equal(after.open, null);
     assert.equal(after.closed[0].max_score, '16-14');
 });
 
-test('idle countdown runs from the stop event', () => {
+test('idle countdown runs from the last playing observation, not the stop event', () => {
     nextId = 1;
     const events = [
         ev(0, { map: 'Nuke', score: '13-7' }),
         ev(300, { playing: false })
     ];
-    // 10 minutes after the last score but only 5 after stopping: still open.
-    const r = segmentStream(events, at(600), config);
-    assert.equal(r.closed.length, 0);
-    assert.ok(r.open);
+    // 10 minutes after the last playing observation: closed, even though the stop was only
+    // 5 minutes ago — stopping is not progress (matches the old last_progress_at semantics).
+    const idle = segmentStream(events, at(600), config);
+    assert.equal(idle.closed.length, 1);
+
+    // A stream still marked playing never idle-closes, no matter how stale.
+    nextId = 1;
+    const stillPlaying = segmentStream([ev(0, { map: 'Nuke', score: '13-7' })], at(3600), config);
+    assert.equal(stillPlaying.closed.length, 0);
+    assert.ok(stillPlaying.open);
 });
 
 test('a relaunch mid-match resumes the same match', () => {

--- a/test/matchDerivation.test.ts
+++ b/test/matchDerivation.test.ts
@@ -1,0 +1,304 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    segmentStream, findCoPlayers, parseRawScore,
+    PresenceEvent, DerivationConfig
+} from '../matchDerivation.js';
+
+const T0 = new Date('2026-01-01T12:00:00.000Z').getTime();
+const at = (seconds: number): Date => new Date(T0 + seconds * 1000);
+
+const config: DerivationConfig = {
+    resetTolerance: 2,
+    matchIdleMs: 10 * 60 * 1000,
+    resetConfirmMs: 30 * 1000
+};
+
+let nextId = 1;
+const ev = (
+    seconds: number,
+    opts: { playing?: boolean; map?: string; mode?: string; score?: string; user?: number; name?: string } = {}
+): PresenceEvent => ({
+    id: nextId++,
+    steam_id: 'A',
+    user_id: opts.user ?? 100,
+    playing: opts.playing ?? true,
+    map: opts.map,
+    mode: opts.mode,
+    raw_score: opts.score,
+    score_total: parseRawScore(opts.score)?.total ?? null,
+    player_name: opts.name,
+    created_at: at(seconds)
+});
+
+test('a single progressing match stays one open segment while playing', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', mode: 'Competitive', score: '1-0' }),
+        ev(60, { map: 'Inferno', mode: 'Competitive', score: '5-3' }),
+        ev(120, { map: 'Inferno', mode: 'Competitive', score: '10-5' })
+    ];
+    const { closed, open } = segmentStream(events, at(180), config);
+    assert.equal(closed.length, 0);
+    assert.ok(open);
+    assert.equal(open!.map, 'Inferno');
+    assert.equal(open!.max_score, '10-5');
+    assert.equal(open!.playing, true);
+});
+
+test('a stopped match closes after the idle window, not before', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '16-14' }),
+        ev(60, { playing: false })
+    ];
+    const before = segmentStream(events, at(60 + 9 * 60), config);
+    assert.equal(before.closed.length, 0);
+    assert.ok(before.open);
+
+    const after = segmentStream(events, at(60 + 11 * 60), config);
+    assert.equal(after.closed.length, 1);
+    assert.equal(after.open, null);
+    assert.equal(after.closed[0].max_score, '16-14');
+});
+
+test('idle countdown runs from the stop event', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Nuke', score: '13-7' }),
+        ev(300, { playing: false })
+    ];
+    // 10 minutes after the last score but only 5 after stopping: still open.
+    const r = segmentStream(events, at(600), config);
+    assert.equal(r.closed.length, 0);
+    assert.ok(r.open);
+});
+
+test('a relaunch mid-match resumes the same match', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '10-5' }),
+        ev(30, { playing: false }),
+        ev(90, { map: 'Inferno', score: '12-5' })
+    ];
+    const { closed, open } = segmentStream(events, at(120), config);
+    assert.equal(closed.length, 0);
+    assert.ok(open);
+    assert.equal(open!.max_score, '12-5');
+    assert.equal(open!.playing, true);
+});
+
+test('a score reset while still playing becomes a boundary once the confirm window passes', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Mirage', score: '14-16' }),
+        ev(60, { map: 'Mirage', score: '1-0' })
+    ];
+    // Within the confirm window: nothing closed yet.
+    const soon = segmentStream(events, at(70), config);
+    assert.equal(soon.closed.length, 0);
+
+    // After the window the old match is over and the dip started the new one.
+    const later = segmentStream(events, at(60 + 31), config);
+    assert.equal(later.closed.length, 1);
+    assert.equal(later.closed[0].max_score, '14-16');
+    assert.ok(later.open);
+    assert.equal(later.open!.max_score, '1-0');
+});
+
+test('a second event in the new low range confirms a reset immediately', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Mirage', score: '14-16' }),
+        ev(60, { map: 'Mirage', score: '1-0' }),
+        ev(90, { map: 'Mirage', score: '2-0' })
+    ];
+    const { closed, open } = segmentStream(events, at(91), config);
+    assert.equal(closed.length, 1);
+    assert.equal(closed[0].max_score, '14-16');
+    assert.ok(open);
+    assert.equal(open!.max_score, '2-0');
+});
+
+test('a flaky dip that returns to the old range does not split the match', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '5-3' }),
+        ev(60, { map: 'Inferno', score: '1-0' }),   // flake
+        ev(90, { map: 'Inferno', score: '8-3' })
+    ];
+    const { closed, open } = segmentStream(events, at(120), config);
+    assert.equal(closed.length, 0);
+    assert.ok(open);
+    assert.equal(open!.max_score, '8-3');
+
+    // ...and the whole thing still finalises as ONE match when idle.
+    nextId = 1;
+    const withStop = [
+        ev(0, { map: 'Inferno', score: '5-3' }),
+        ev(60, { map: 'Inferno', score: '1-0' }),
+        ev(90, { map: 'Inferno', score: '8-3' }),
+        ev(120, { playing: false })
+    ];
+    const idle = segmentStream(withStop, at(120 + 11 * 60), config);
+    assert.equal(idle.closed.length, 1);
+    assert.equal(idle.closed[0].max_score, '8-3');
+});
+
+test('a small drop within tolerance is not a reset signal', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '5-5' }),   // total 10
+        ev(60, { map: 'Inferno', score: '5-4' })   // total 9, within tolerance 2
+    ];
+    const { closed, open } = segmentStream(events, at(600), config);
+    assert.equal(closed.length, 0);
+    assert.ok(open);
+    assert.equal(open!.max_score, '5-5');
+});
+
+test('a map change is an immediate boundary', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', mode: 'Competitive', score: '16-14' }),
+        ev(60, { map: 'Mirage', mode: 'Competitive', score: '1-0' })
+    ];
+    const { closed, open } = segmentStream(events, at(61), config);
+    assert.equal(closed.length, 1);
+    assert.equal(closed[0].map, 'Inferno');
+    assert.ok(open);
+    assert.equal(open!.map, 'Mirage');
+});
+
+test('a mode change is an immediate boundary', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', mode: 'Competitive', score: '16-14' }),
+        ev(60, { map: 'Inferno', mode: 'Wingman', score: '1-0' })
+    ];
+    const { closed, open } = segmentStream(events, at(61), config);
+    assert.equal(closed.length, 1);
+    assert.equal(closed[0].mode, 'Competitive');
+    assert.ok(open);
+    assert.equal(open!.mode, 'Wingman');
+});
+
+test('missing map/mode on an event never causes a boundary; first non-null fills in', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { score: '1-0' }),                                   // no map yet
+        ev(60, { map: 'Inferno', mode: 'Competitive', score: '3-1' }),
+        ev(120, { score: '5-1' })                                  // map/mode dropped from presence
+    ];
+    const { closed, open } = segmentStream(events, at(121), config);
+    assert.equal(closed.length, 0);
+    assert.ok(open);
+    assert.equal(open!.map, 'Inferno');
+    assert.equal(open!.mode, 'Competitive');
+    assert.equal(open!.max_score, '5-1');
+});
+
+test('two boundaries produce two closed matches and one open', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '13-7' }),
+        ev(60, { map: 'Mirage', score: '13-5' }),
+        ev(120, { map: 'Nuke', score: '1-0' })
+    ];
+    const { closed, open } = segmentStream(events, at(121), config);
+    assert.equal(closed.length, 2);
+    assert.equal(closed[0].map, 'Inferno');
+    assert.equal(closed[1].map, 'Mirage');
+    assert.ok(open);
+    assert.equal(open!.map, 'Nuke');
+});
+
+test('latest player name and user mapping win; started_at is the first event', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '1-0', name: 'OldNick', user: 100 }),
+        ev(60, { map: 'Inferno', score: '5-0', name: 'NewNick', user: 101 })
+    ];
+    const { open } = segmentStream(events, at(61), config);
+    assert.ok(open);
+    assert.equal(open!.player_name, 'NewNick');
+    assert.equal(open!.user_id, 101);
+    assert.equal(open!.started_at.getTime(), at(0).getTime());
+    assert.equal(open!.lastEventId, 2);
+});
+
+test('co-player: same map, mode and score at the same time is found with their name', () => {
+    nextId = 1;
+    const seg = segmentStream([
+        ev(0, { map: 'Inferno', mode: 'Competitive', score: '5-3' }),
+        ev(60, { map: 'Inferno', mode: 'Competitive', score: '6-3' })
+    ], at(61), config).open!;
+
+    nextId = 100;
+    const other: PresenceEvent[] = [
+        { ...ev(-30, { map: 'Inferno', mode: 'Competitive', score: '5-3', user: 200, name: 'Bravo' }), steam_id: 'B' }
+    ];
+    const cos = findCoPlayers(seg, new Map([['B', other]]), config);
+    assert.equal(cos.length, 1);
+    assert.equal(cos[0].user_id, 200);
+    assert.equal(cos[0].player_name, 'Bravo');
+});
+
+test('co-player: different map, diverging score, stopped, or own alt account do not match', () => {
+    nextId = 1;
+    const seg = segmentStream([
+        ev(0, { map: 'Inferno', mode: 'Competitive', score: '5-3' }),
+        ev(60, { map: 'Inferno', mode: 'Competitive', score: '6-3' })
+    ], at(61), config).open!;
+
+    nextId = 100;
+    const otherMap: PresenceEvent[] = [{ ...ev(-30, { map: 'Mirage', mode: 'Competitive', score: '5-3', user: 201 }), steam_id: 'C' }];
+    const divergent: PresenceEvent[] = [{ ...ev(-30, { map: 'Inferno', mode: 'Competitive', score: '16-14', user: 202 }), steam_id: 'D' }];
+    const stopped: PresenceEvent[] = [{ ...ev(-30, { playing: false, user: 203 }), steam_id: 'E' }];
+    const ownAlt: PresenceEvent[] = [{ ...ev(-30, { map: 'Inferno', mode: 'Competitive', score: '5-3', user: 100 }), steam_id: 'F' }];
+
+    const cos = findCoPlayers(seg, new Map([
+        ['C', otherMap], ['D', divergent], ['E', stopped], ['F', ownAlt]
+    ]), config);
+    assert.equal(cos.length, 0);
+});
+
+test('co-player: someone who left mid-match is still recorded (point-in-time semantics)', () => {
+    nextId = 1;
+    const seg = segmentStream([
+        ev(0, { map: 'Inferno', mode: 'Competitive', score: '5-3' }),
+        ev(300, { map: 'Inferno', mode: 'Competitive', score: '20-10' })
+    ], at(301), config).open!;
+
+    nextId = 100;
+    const other: PresenceEvent[] = [
+        { ...ev(-10, { map: 'Inferno', mode: 'Competitive', score: '5-3', user: 210 }), steam_id: 'B' },
+        { ...ev(120, { playing: false, user: 210 }), steam_id: 'B' }
+    ];
+    // At the segment's first observation the states matched; the later divergence doesn't erase it.
+    const cos = findCoPlayers(seg, new Map([['B', other]]), config);
+    assert.equal(cos.length, 1);
+    assert.equal(cos[0].user_id, 210);
+});
+
+test('an unparseable score is still recorded and replaced by the first parseable one', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: 'warmup' }),
+        ev(60, { map: 'Inferno', score: '2-1' })
+    ];
+    const { open } = segmentStream(events, at(61), config);
+    assert.ok(open);
+    assert.equal(open!.max_score, '2-1');
+});
+
+test('a scoreless match is derivable but carries no score', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno' }),
+        ev(60, { playing: false })
+    ];
+    const { closed } = segmentStream(events, at(60 + 11 * 60), config);
+    assert.equal(closed.length, 1);
+    assert.equal(closed[0].max_score, undefined);
+});


### PR DESCRIPTION
Match detection previously mutated a single current_match row per tick and
deleted it on finalisation, so one flaky presence tick could irreversibly
split or merge a match. Store every relevant presence transition (per Steam
account) in a new append-only presence_event table instead, and derive match
boundaries, idle finalisation and co-players retrospectively by replaying the
stream (matchDerivation.ts, pure and unit-tested).

- Score resets now need confirmation (a further event in the new range, or
  standing uncontradicted for MATCH_RESET_CONFIRM_MS) before they split a
  match; a dip that returns to the old range is folded away as noise.
- A per-stream cursor advances atomically with the game_history insert,
  making finalisation exactly-once; it is the only remaining durable match
  state. current_match(+_coplayer) are dropped via a guarded migration.
- Co-players are reconstructed by comparing streams point-in-time instead of
  sampling live presence.
- Events are deduplicated on write (gameid-only re-broadcasts store nothing)
  and pruned past a TTL, never past a cursor.

Live status messages (game_update), end-of-game announcement grouping and
game_history are unchanged; history data remains fully usable.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QvtvvMPxLXoshLhvirXob4