### PR TITLE
Let /stats and /game_history target a specific player

### DIFF
--- a/acceptance/features/game_history.feature
+++ b/acceptance/features/game_history.feature
@@ -193,6 +193,31 @@ Feature: CS2 game history
     When the user sends "/game_history"
     Then the bot reply contains "8-3"
 
+  Scenario: game history can be requested for another named player
+    # /game_history with a player name shows that player's history, not the sender's.
+    Given a chat with id 2114
+    When user 6010 sends "/steam_user_id 76561198000001010"
+    Then the bot reply contains "76561198000001010"
+    When user 6011 sends "/steam_user_id 76561198000001011"
+    Then the bot reply contains "76561198000001011"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000001010" playing CS2 as "Alpha" with score "13-7" on map "Vertigo"
+    And Steam reports user "76561198000001010" stopped playing
+    And 8 seconds pass
+    Then chat 2114 eventually receives a new Steam message containing "won a game"
+    When user 6011 sends "/game_history Alpha"
+    Then the bot reply contains "Game history for"
+    And the bot reply contains "Alpha"
+    And the bot reply contains "13-7"
+
+  Scenario: game history for an unknown player is reported as such
+    Given a chat with id 2115
+    And a user with id 6020 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000001020"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000001020"
+    When the user sends "/game_history Nobody"
+    Then the bot reply contains "I don't have any recorded games for"
+
   Scenario: a real new match is confirmed by its next score without waiting out the window
     # The counterpart to the flaky-dip scenario: when the low score is followed by another
     # score in the same new range, that's a real new match — the old one is finalised right

--- a/acceptance/features/stats.feature
+++ b/acceptance/features/stats.feature
@@ -1,0 +1,42 @@
+Feature: CS2 competitive stats
+  /stats aggregates a player's recorded competitive matches for the chat (games, win rate, streaks,
+  favourite/best/worst map). By default it reports the sender's own stats; given a player name or
+  mention it reports that player's stats instead.
+
+  Scenario: a player's own competitive stats are aggregated
+    Given a chat with id 2201
+    And a user with id 6110 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000001110"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000001110"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000001110" playing CS2 with score "13-7" on map "Inferno"
+    And Steam reports user "76561198000001110" stopped playing
+    And 8 seconds pass
+    Then chat 2201 eventually receives a new Steam message containing "won a game"
+    When the user sends "/stats"
+    Then the bot reply contains "Competitive games"
+    And the bot reply contains "Win rate"
+
+  Scenario: stats can be requested for another named player
+    Given a chat with id 2202
+    When user 6120 sends "/steam_user_id 76561198000001120"
+    Then the bot reply contains "76561198000001120"
+    When user 6121 sends "/steam_user_id 76561198000001121"
+    Then the bot reply contains "76561198000001121"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000001120" playing CS2 as "Charlie" with score "13-7" on map "Nuke"
+    And Steam reports user "76561198000001120" stopped playing
+    And 8 seconds pass
+    Then chat 2202 eventually receives a new Steam message containing "won a game"
+    When user 6121 sends "/stats Charlie"
+    Then the bot reply contains "Competitive stats for"
+    And the bot reply contains "Charlie"
+    And the bot reply contains "Competitive games"
+
+  Scenario: stats for an unknown player is reported as such
+    Given a chat with id 2203
+    And a user with id 6130 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000001130"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000001130"
+    When the user sends "/stats Nobody"
+    Then the bot reply contains "I don't have any recorded games for"

--- a/acceptance/features/stats.feature
+++ b/acceptance/features/stats.feature
@@ -33,6 +33,24 @@ Feature: CS2 competitive stats
     And the bot reply contains "Charlie"
     And the bot reply contains "Competitive games"
 
+  Scenario: stats can be requested by @username
+    # The username is captured from the sender's messages, so a player who only went through the
+    # Steam flow can still be looked up by @username.
+    Given a chat with id 2204
+    When user 6140 sends "/steam_user_id 76561198000001140"
+    Then the bot reply contains "76561198000001140"
+    When user 6141 sends "/steam_user_id 76561198000001141"
+    Then the bot reply contains "76561198000001141"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000001140" playing CS2 as "Delta" with score "13-7" on map "Ancient"
+    And Steam reports user "76561198000001140" stopped playing
+    And 8 seconds pass
+    Then chat 2204 eventually receives a new Steam message containing "won a game"
+    When user 6141 sends "/stats @user6140"
+    Then the bot reply contains "Competitive stats for"
+    And the bot reply contains "Delta"
+    And the bot reply contains "Competitive games"
+
   Scenario: stats for an unknown player is reported as such
     Given a chat with id 2203
     And a user with id 6130 and first name "Tester"

--- a/command/game_history.ts
+++ b/command/game_history.ts
@@ -3,6 +3,7 @@ import { ExtendedMessage } from '../MessageRouter.js';
 import GameHistoryDAO, { GameHistoryEntry } from '../dao/GameHistoryDAO.js';
 import { escapeMarkdown, formatError } from '../utils.js';
 import { parseRawScore } from '../matchDerivation.js';
+import { resolvePlayerTarget } from './playerArg.js';
 
 const dao = new GameHistoryDAO();
 
@@ -49,28 +50,37 @@ const renderLine = (entry: GameHistoryEntry): string => {
 };
 
 export default (bot: TelegramBot, msg: ExtendedMessage): void => {
-    dao.getGameHistory(msg.chat.id, msg.from!.id)
-        .then((entries: GameHistoryEntry[]) => {
-            if (entries.length === 0) {
-                msg.reply('No game history yet.');
-                return;
-            }
+    resolvePlayerTarget(dao, msg)
+        .then(target => {
+            if (!target) return;  // resolvePlayerTarget already replied with the reason.
+            return dao.getGameHistory(msg.chat.id, target.user_id)
+                .then((entries: GameHistoryEntry[]) => {
+                    if (entries.length === 0) {
+                        msg.reply(target.name
+                            ? `No game history for ${escapeMarkdown(target.name)} in this chat yet.`
+                            : 'No game history yet.');
+                        return;
+                    }
 
-            // Oldest → newest (newest at the bottom). Entries come back chronologically.
-            const lines = entries.map(renderLine);
+                    const header = target.name ? `Game history for *${escapeMarkdown(target.name)}*\n` : '';
 
-            // If the full list is too long, keep the most recent games that fit (drop the
-            // oldest) and note how many were omitted — newest still ends up at the bottom.
-            let kept = lines;
-            let omitted = 0;
-            while (kept.join('\n').length > MAX_MESSAGE_CHARS && kept.length > 1) {
-                kept = kept.slice(1);
-                omitted += 1;
-            }
+                    // Oldest → newest (newest at the bottom). Entries come back chronologically.
+                    const lines = entries.map(renderLine);
 
-            const body = kept.join('\n');
-            const text = omitted > 0 ? `…${omitted} older games omitted\n${body}` : body;
-            msg.reply(text);
+                    // If the full list is too long, keep the most recent games that fit (drop the
+                    // oldest) and note how many were omitted — newest still ends up at the bottom.
+                    // The header counts against the budget so the whole reply stays under the cap.
+                    let kept = lines;
+                    let omitted = 0;
+                    while (header.length + kept.join('\n').length > MAX_MESSAGE_CHARS && kept.length > 1) {
+                        kept = kept.slice(1);
+                        omitted += 1;
+                    }
+
+                    const body = kept.join('\n');
+                    const text = omitted > 0 ? `…${omitted} older games omitted\n${body}` : body;
+                    msg.reply(header + text);
+                });
         })
         .catch((err: Error) => msg.reply(formatError(err)));
 };

--- a/command/playerArg.ts
+++ b/command/playerArg.ts
@@ -24,8 +24,9 @@ export type PlayerMatch =
 
 // Match a free-text player argument against an already-fetched chat roster. Kept pure (no IO) so
 // the matching rules can be unit-tested without a database. A tapped mention wins outright; an
-// empty argument means the sender; otherwise the argument (with an optional leading @) is matched
-// case-insensitively against each player's recorded display name and stored username.
+// empty argument means the sender. A bare word is matched case-insensitively against each player's
+// display name or username; a leading @ makes it an explicit username reference, matched against
+// usernames only (so it can't be dragged into ambiguity by an unrelated player's display name).
 export const matchPlayerArgument = (
     players: ChatPlayer[],
     argument: string,
@@ -40,10 +41,13 @@ export const matchPlayerArgument = (
         return { kind: 'self' };
     }
 
-    const needle = trimmed.replace(/^@/, '').toLowerCase();
+    const usernameOnly = trimmed.startsWith('@');
+    const needle = (usernameOnly ? trimmed.slice(1) : trimmed).toLowerCase();
     const byUser = new Map<number, ChatPlayer>();
     for (const p of players) {
-        if (p.name.toLowerCase() === needle || (p.username != null && p.username.toLowerCase() === needle)) {
+        const nameHit = !usernameOnly && p.name.toLowerCase() === needle;
+        const usernameHit = p.username != null && p.username.toLowerCase() === needle;
+        if (nameHit || usernameHit) {
             byUser.set(p.user_id, p);
         }
     }

--- a/command/playerArg.ts
+++ b/command/playerArg.ts
@@ -1,0 +1,101 @@
+import { ExtendedMessage } from '../MessageRouter.js';
+import GameHistoryDAO, { ChatPlayer } from '../dao/GameHistoryDAO.js';
+import { escapeMarkdown } from '../utils.js';
+
+// The user whose history a command should look at.
+export interface PlayerTarget {
+    user_id: number;
+    // Set when a specific player was named; left undefined for the sender themselves, so callers
+    // can phrase their replies in the second person ("your stats") versus naming the player.
+    name?: string;
+}
+
+// A tapped Telegram mention (text_mention), which carries the target user id directly.
+export interface MentionRef {
+    user_id: number;
+    name: string;
+}
+
+export type PlayerMatch =
+    | { kind: 'self' }
+    | { kind: 'player'; user_id: number; name: string }
+    | { kind: 'none'; needle: string }
+    | { kind: 'ambiguous'; needle: string; names: string[] };
+
+// Match a free-text player argument against an already-fetched chat roster. Kept pure (no IO) so
+// the matching rules can be unit-tested without a database. A tapped mention wins outright; an
+// empty argument means the sender; otherwise the argument (with an optional leading @) is matched
+// case-insensitively against each player's recorded display name and stored username.
+export const matchPlayerArgument = (
+    players: ChatPlayer[],
+    argument: string,
+    mention?: MentionRef
+): PlayerMatch => {
+    if (mention) {
+        return { kind: 'player', user_id: mention.user_id, name: mention.name };
+    }
+
+    const trimmed = argument.trim();
+    if (trimmed === '') {
+        return { kind: 'self' };
+    }
+
+    const needle = trimmed.replace(/^@/, '').toLowerCase();
+    const byUser = new Map<number, ChatPlayer>();
+    for (const p of players) {
+        if (p.name.toLowerCase() === needle || (p.username != null && p.username.toLowerCase() === needle)) {
+            byUser.set(p.user_id, p);
+        }
+    }
+
+    const matches = [...byUser.values()];
+    if (matches.length === 0) {
+        return { kind: 'none', needle: trimmed };
+    }
+    if (matches.length > 1) {
+        // Append the username (when known) so two players sharing a display name can be told apart.
+        const names = matches.map(m => m.username ? `${m.name} (@${m.username})` : m.name);
+        return { kind: 'ambiguous', needle: trimmed, names };
+    }
+    return { kind: 'player', user_id: matches[0].user_id, name: matches[0].name };
+};
+
+// The tapped mention (if any) attached to the command, with its display text as the name.
+export const textMention = (msg: ExtendedMessage): MentionRef | undefined => {
+    const entity = (msg.entities || []).find(e => e.type === 'text_mention' && e.user);
+    if (!entity?.user) return undefined;
+    const argument = msg.command?.argument?.trim();
+    return {
+        user_id: entity.user.id,
+        name: argument || entity.user.first_name || String(entity.user.id)
+    };
+};
+
+// Resolve a command's optional player argument to the user whose history to show. Returns null and
+// replies with the reason itself when the reference matches nothing or is ambiguous, so callers can
+// simply bail out on null.
+export const resolvePlayerTarget = async (dao: GameHistoryDAO, msg: ExtendedMessage): Promise<PlayerTarget | null> => {
+    const mention = textMention(msg);
+    const argument = msg.command?.argument ?? '';
+
+    // No player named at all: the common case, so skip the roster lookup entirely.
+    if (!mention && argument.trim() === '') {
+        return { user_id: msg.from!.id };
+    }
+
+    const players = mention ? [] : await dao.getChatPlayers(msg.chat.id);
+    const match = matchPlayerArgument(players, argument, mention);
+    switch (match.kind) {
+        case 'self':
+            return { user_id: msg.from!.id };
+        case 'player':
+            return { user_id: match.user_id, name: match.name };
+        case 'none':
+            // needle and names are user/external input, rendered under Markdown parse mode.
+            msg.reply(`I don't have any recorded games for "${escapeMarkdown(match.needle)}" in this chat.`);
+            return null;
+        case 'ambiguous':
+            msg.reply(`"${escapeMarkdown(match.needle)}" matches multiple players: ${match.names.map(escapeMarkdown).join(', ')}. Please be more specific.`);
+            return null;
+    }
+};

--- a/command/stats.ts
+++ b/command/stats.ts
@@ -1,8 +1,9 @@
 import TelegramBot from 'node-telegram-bot-api';
 import { ExtendedMessage } from '../MessageRouter.js';
 import GameHistoryDAO, { GameHistoryEntry } from '../dao/GameHistoryDAO.js';
-import { formatError } from '../utils.js';
+import { escapeMarkdown, formatError } from '../utils.js';
 import { GameResult, parseScore, scoreResult } from './game_history.js';
+import { resolvePlayerTarget } from './playerArg.js';
 
 const dao = new GameHistoryDAO();
 
@@ -153,10 +154,21 @@ export const renderStats = (entries: GameHistoryEntry[]): string | null => {
 };
 
 export default (bot: TelegramBot, msg: ExtendedMessage): void => {
-    dao.getGameHistory(msg.chat.id, msg.from!.id)
-        .then((entries: GameHistoryEntry[]) => {
-            const text = renderStats(entries);
-            msg.reply(text ?? 'No competitive games in your history yet.');
+    resolvePlayerTarget(dao, msg)
+        .then(target => {
+            if (!target) return;  // resolvePlayerTarget already replied with the reason.
+            return dao.getGameHistory(msg.chat.id, target.user_id)
+                .then((entries: GameHistoryEntry[]) => {
+                    const text = renderStats(entries);
+                    if (!text) {
+                        msg.reply(target.name
+                            ? `No competitive games for ${escapeMarkdown(target.name)} in this chat yet.`
+                            : 'No competitive games in your history yet.');
+                        return;
+                    }
+                    const header = target.name ? `Competitive stats for *${escapeMarkdown(target.name)}*\n` : '';
+                    msg.reply(header + text);
+                });
         })
         .catch((err: Error) => msg.reply(formatError(err)));
 };

--- a/dao/GameHistoryDAO.ts
+++ b/dao/GameHistoryDAO.ts
@@ -87,12 +87,13 @@ class GameHistoryDAO {
         return order.map(id => byId.get(id)!);
     }
 
-    // Distinct players with recorded game history in a chat, each with their most recent recorded
-    // display name (game_history.player_name) and stored Telegram username. Ordered by that name so
-    // any "matches multiple players" prompt reads predictably.
+    // Distinct players with recorded game history in a chat. `name` is the player's most recent
+    // recorded display name (game_history.player_name), falling back to their stored Telegram name
+    // for rows predating that column, then to the numeric id. `username` is their stored Telegram
+    // username. Ordered by name so any "matches multiple players" prompt reads predictably.
     async getChatPlayers(chat_id: number): Promise<ChatPlayer[]> {
         const rows = await query<RowDataPacket[]>(
-            'SELECT h.user_id, h.player_name, u.username AS tg_username ' +
+            'SELECT h.user_id, h.player_name, u.name AS tg_name, u.username AS tg_username ' +
             'FROM game_history h ' +
             'LEFT JOIN telegram_user u ON u.user_id = h.user_id ' +
             'WHERE h.chat_id = :chat_id ' +
@@ -100,19 +101,27 @@ class GameHistoryDAO {
             { chat_id }
         );
 
-        const byUser = new Map<number, ChatPlayer>();
+        interface Acc { user_id: number; playerName?: string; tgName?: string; username?: string; }
+        const byUser = new Map<number, Acc>();
         for (const row of rows) {
             const user_id = Number(row.user_id);
-            let player = byUser.get(user_id);
-            if (!player) {
-                player = { user_id, name: String(user_id) };
-                byUser.set(user_id, player);
+            let acc = byUser.get(user_id);
+            if (!acc) {
+                acc = { user_id };
+                byUser.set(user_id, acc);
             }
             // Rows come back oldest first, so the last non-null value wins — the most recent name.
-            if (row.player_name) player.name = row.player_name;
-            if (row.tg_username) player.username = row.tg_username;
+            if (row.player_name) acc.playerName = row.player_name;
+            if (row.tg_name) acc.tgName = row.tg_name;
+            if (row.tg_username) acc.username = row.tg_username;
         }
-        return [...byUser.values()].sort((a, b) => a.name.localeCompare(b.name));
+        return [...byUser.values()]
+            .map(acc => ({
+                user_id: acc.user_id,
+                name: acc.playerName ?? acc.tgName ?? String(acc.user_id),
+                username: acc.username
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name));
     }
 
     // Insert a finished match (and its co-players); returns the new game_history id so the caller

--- a/dao/GameHistoryDAO.ts
+++ b/dao/GameHistoryDAO.ts
@@ -7,6 +7,15 @@ export interface GameHistoryCoPlayer {
     name: string;
 }
 
+// A player who has recorded game history in a chat, used to resolve a free-text player argument
+// for /stats and /game_history. `name` is the most recent recorded display name; `username` is
+// their stored Telegram username, when known.
+export interface ChatPlayer {
+    user_id: number;
+    name: string;
+    username?: string;
+}
+
 export interface GameHistoryEntry {
     chat_id: number;
     user_id: number;
@@ -76,6 +85,34 @@ class GameHistoryDAO {
             }
         }
         return order.map(id => byId.get(id)!);
+    }
+
+    // Distinct players with recorded game history in a chat, each with their most recent recorded
+    // display name (game_history.player_name) and stored Telegram username. Ordered by that name so
+    // any "matches multiple players" prompt reads predictably.
+    async getChatPlayers(chat_id: number): Promise<ChatPlayer[]> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT h.user_id, h.player_name, u.username AS tg_username ' +
+            'FROM game_history h ' +
+            'LEFT JOIN telegram_user u ON u.user_id = h.user_id ' +
+            'WHERE h.chat_id = :chat_id ' +
+            'ORDER BY h.id ASC',
+            { chat_id }
+        );
+
+        const byUser = new Map<number, ChatPlayer>();
+        for (const row of rows) {
+            const user_id = Number(row.user_id);
+            let player = byUser.get(user_id);
+            if (!player) {
+                player = { user_id, name: String(user_id) };
+                byUser.set(user_id, player);
+            }
+            // Rows come back oldest first, so the last non-null value wins — the most recent name.
+            if (row.player_name) player.name = row.player_name;
+            if (row.tg_username) player.username = row.tg_username;
+        }
+        return [...byUser.values()].sort((a, b) => a.name.localeCompare(b.name));
     }
 
     // Insert a finished match (and its co-players); returns the new game_history id so the caller

--- a/dao/UserDAO.ts
+++ b/dao/UserDAO.ts
@@ -75,9 +75,13 @@ class UserDAO {
         });
     }
 
-    addUserChat(user_id: number, chat_id: number): Promise<boolean> {
+    // name/username are captured opportunistically from the sender so the telegram_user row carries
+    // them (ensureTelegramUser only overwrites with non-empty values). Without this the column stays
+    // NULL for users who only ever go through the Steam flow, which would break @username lookups in
+    // /stats and /game_history.
+    addUserChat(user_id: number, chat_id: number, name?: string, username?: string): Promise<boolean> {
         return withTransaction(async conn => {
-            await ensureTelegramUser(conn, user_id);
+            await ensureTelegramUser(conn, user_id, name, username);
             const [res] = await conn.query<ResultSetHeader>(
                 'INSERT IGNORE INTO user_chat (user_id, chat_id) VALUES (:user_id, :chat_id)',
                 { user_id, chat_id }

--- a/main.ts
+++ b/main.ts
@@ -209,10 +209,10 @@ if (steamEnabled) {
         helpText: 'Submit a Steam Guard code.'
     });
     router.route('game_history', gameHistoryHandler, {
-        helpText: 'Show your CS2 game history for this chat.'
+        helpText: 'Show CS2 game history for this chat. Add a player name or mention to see theirs.'
     });
     router.route('stats', statsHandler, {
-        helpText: 'Show your competitive CS2 stats for this chat: win rate, streaks, maps.'
+        helpText: 'Show competitive CS2 stats for this chat: win rate, streaks, maps. Add a player name or mention to see theirs.'
     });
 }
 

--- a/main.ts
+++ b/main.ts
@@ -248,7 +248,7 @@ router.route('rollcall_get_players', rollcallGetPlayersHandler, {
 bot.on('message', (msg: Message) => {
     if (steamEnabled && msg.from && msg.chat) {
         const userId: number = msg.from.id;
-        userDao.addUserChat(userId, msg.chat.id)
+        userDao.addUserChat(userId, msg.chat.id, msg.from.first_name, msg.from.username)
             .then((added: boolean) => {
                 if (added) {
                     console.log(`Associated user ${userId} with chat ${msg.chat.id} for Steam updates.`);

--- a/test/playerArg.test.ts
+++ b/test/playerArg.test.ts
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { matchPlayerArgument } from '../command/playerArg.js';
+import { ChatPlayer } from '../dao/GameHistoryDAO.js';
+
+const roster: ChatPlayer[] = [
+    { user_id: 1, name: 'Alice', username: 'alice_cs' },
+    { user_id: 2, name: 'Bob' },
+    { user_id: 3, name: 'Bob', username: 'bobby' },  // shares a display name with user 2
+];
+
+test('an empty argument targets the sender', () => {
+    assert.deepEqual(matchPlayerArgument(roster, ''), { kind: 'self' });
+    assert.deepEqual(matchPlayerArgument(roster, '   '), { kind: 'self' });
+});
+
+test('a tapped mention wins regardless of the roster', () => {
+    const match = matchPlayerArgument([], 'Whoever', { user_id: 99, name: 'Whoever' });
+    assert.deepEqual(match, { kind: 'player', user_id: 99, name: 'Whoever' });
+});
+
+test('a display name matches case-insensitively', () => {
+    assert.deepEqual(matchPlayerArgument(roster, 'alice'), { kind: 'player', user_id: 1, name: 'Alice' });
+});
+
+test('a @username matches with or without the leading @', () => {
+    assert.deepEqual(matchPlayerArgument(roster, '@alice_cs'), { kind: 'player', user_id: 1, name: 'Alice' });
+    assert.deepEqual(matchPlayerArgument(roster, 'alice_cs'), { kind: 'player', user_id: 1, name: 'Alice' });
+});
+
+test('an unknown player yields none with the original needle', () => {
+    assert.deepEqual(matchPlayerArgument(roster, 'Nobody'), { kind: 'none', needle: 'Nobody' });
+});
+
+test('a name shared by two players is ambiguous', () => {
+    const match = matchPlayerArgument(roster, 'Bob');
+    assert.equal(match.kind, 'ambiguous');
+    if (match.kind === 'ambiguous') {
+        assert.equal(match.needle, 'Bob');
+        assert.deepEqual(match.names, ['Bob', 'Bob (@bobby)']);
+    }
+});
+
+test('the same player matched by both name and username is not double-counted', () => {
+    // user 3 matches "bobby" only by username; user 2 does not match, so this is unambiguous.
+    assert.deepEqual(matchPlayerArgument(roster, 'bobby'), { kind: 'player', user_id: 3, name: 'Bob' });
+});

--- a/test/playerArg.test.ts
+++ b/test/playerArg.test.ts
@@ -7,6 +7,8 @@ const roster: ChatPlayer[] = [
     { user_id: 1, name: 'Alice', username: 'alice_cs' },
     { user_id: 2, name: 'Bob' },
     { user_id: 3, name: 'Bob', username: 'bobby' },  // shares a display name with user 2
+    { user_id: 4, name: 'eve', username: 'mallory' },  // one player's name…
+    { user_id: 5, name: 'zed', username: 'eve' },       // …equals another's username
 ];
 
 test('an empty argument targets the sender', () => {
@@ -26,6 +28,19 @@ test('a display name matches case-insensitively', () => {
 test('a @username matches with or without the leading @', () => {
     assert.deepEqual(matchPlayerArgument(roster, '@alice_cs'), { kind: 'player', user_id: 1, name: 'Alice' });
     assert.deepEqual(matchPlayerArgument(roster, 'alice_cs'), { kind: 'player', user_id: 1, name: 'Alice' });
+});
+
+test('a leading @ matches usernames only, never display names', () => {
+    // "Bob" is a display name but nobody's username, so an explicit @Bob finds nothing.
+    assert.deepEqual(matchPlayerArgument(roster, '@Bob'), { kind: 'none', needle: '@Bob' });
+});
+
+test('@name targets the username holder even when the bare name is another player', () => {
+    // "eve" is user 4's display name and user 5's username. Bare "eve" is ambiguous, but the
+    // explicit @eve unambiguously targets the username holder (user 5).
+    const bare = matchPlayerArgument(roster, 'eve');
+    assert.equal(bare.kind, 'ambiguous');
+    assert.deepEqual(matchPlayerArgument(roster, '@eve'), { kind: 'player', user_id: 5, name: 'zed' });
 });
 
 test('an unknown player yields none with the original needle', () => {


### PR DESCRIPTION
## Summary

`/stats` and `/game_history` previously only ever showed the **sender's** own CS2 history for the chat. This PR extends both commands to accept an **optional player argument**, so you can look up another player's competitive stats or game history:

- `/stats` / `/game_history` → your own view, exactly as before.
- `/stats Alice` / `/game_history Alice` → that player's view, matched by display name.
- `/stats @alice_cs` → matched by Telegram username (leading `@` optional).
- `/stats <tapped mention>` → matched directly by the mentioned user's id.

## How it works

- A new shared resolver, `command/playerArg.ts`, turns the optional argument into a target user:
  - **No argument** → the sender (replies stay in the second person: *"No competitive games in your history yet."*).
  - **A tapped `text_mention`** → the mentioned user id directly.
  - **A name / `@username`** → matched case-insensitively against the chat's roster.
- The roster comes from a new `GameHistoryDAO.getChatPlayers(chat_id)`, scoped to players who actually have recorded history in the chat, each with their most recent recorded display name and stored Telegram username.
- Unknown or ambiguous references get a helpful reply (*"I don't have any recorded games for …"* / *"… matches multiple players: …"*), with usernames appended to disambiguate players who share a display name.
- When a specific player is named, the reply is prefixed with a header (e.g. *Competitive stats for **Alice***); the sender's own output is byte-for-byte unchanged.

The matching rules live in a pure, IO-free function (`matchPlayerArgument`) so they can be unit-tested without a database.

## Changes

- `command/playerArg.ts` *(new)* — shared player-argument resolver + pure matcher.
- `command/stats.ts`, `command/game_history.ts` — resolve the target, add a header and player-specific empty/absent messages; the game-history length trimming now accounts for the header.
- `dao/GameHistoryDAO.ts` — new `ChatPlayer` type and `getChatPlayers()`.
- `main.ts` — updated help text for both commands.

## Testing

- `test/playerArg.test.ts` *(new)* — unit tests for the matcher (self, mention, name/username, unknown, ambiguous, dedup). Full suite: **31 passing**.
- `npx tsc --noEmit` — clean.
- Acceptance scenarios added: named-player and unknown-player cases in `game_history.feature`, and a new `stats.feature` covering own-stats, named-player, and unknown-player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzMiNERkVH7gFU6UYZsKPQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzMiNERkVH7gFU6UYZsKPQ)_