### PR TITLE
Add live round tracking, session match overview and admin match deletion

### DIFF
--- a/SteamService.ts
+++ b/SteamService.ts
@@ -4,15 +4,15 @@ import TelegramBot from 'node-telegram-bot-api';
 import UserDAO, { UserSettings } from './dao/UserDAO.js';
 import ChatDAO, { ChatSettings } from './dao/ChatDAO.js';
 import GameUpdateDAO, { GameUpdate } from './dao/GameUpdateDAO.js';
-import GameHistoryDAO, { GameHistoryEntry, GameHistoryCoPlayer, SiblingMatch } from './dao/GameHistoryDAO.js';
+import GameHistoryDAO, { GameHistoryEntry, GameHistoryCoPlayer, SessionMatch, SiblingMatch } from './dao/GameHistoryDAO.js';
 import PresenceEventDAO from './dao/PresenceEventDAO.js';
 import RollcallPlayerDAO from './dao/RollcallPlayerDAO.js';
 import { escapeMarkdown } from './utils.js';
 import { parseMention } from './rsvp.js';
 import { saveSteamFile, readSteamFile, withTransaction } from './dao/Database.js';
 import {
-    segmentStream, findCoPlayers, parseRawScore as parseRawScoreFn,
-    DerivationConfig, MatchSegment, PresenceEvent
+    segmentStream, findCoPlayers, deriveRounds, parseRawScore as parseRawScoreFn,
+    DerivationConfig, MatchSegment, PresenceEvent, RoundOutcome
 } from './matchDerivation.js';
 
 // A finished match with no further score progress is recorded once it has been idle
@@ -46,6 +46,11 @@ const PRESENCE_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 // How old another account's last observation may be and still count as its "state" for
 // co-player matching (the live-presence check this replaces was at most minutes stale).
 const CO_PLAYER_STALE_MS = 15 * 60 * 1000;
+
+// The live message's session overview lists matches that ended after the message was created,
+// widened by this slack: the session's first presence event precedes the message it triggers,
+// so a match observed only around that instant would otherwise fall just outside the window.
+const SESSION_OVERVIEW_SLACK_MS = 60 * 1000;
 
 const DERIVATION_CONFIG: DerivationConfig = {
     resetTolerance: RESET_TOLERANCE,
@@ -382,6 +387,9 @@ class SteamService {
         // (/game_history) and the end-of-game notification is gated per chat at finalisation.
         await this.recordPresence(steamId, tgUserId, { playing: true, map, mode, rawScore, playerName });
 
+        // Per-round outcomes of the current match, replayed from the (just-updated) stream.
+        const rounds = await this.getLiveRounds(steamId);
+
         const chats = await this.userDao.getUserChats(tgUserId);
         if (chats.length === 0) {
             console.debug(`No chats found for user ${tgUserId} (Steam ID: ${steamId}). Cannot publish update.`);
@@ -398,10 +406,11 @@ class SteamService {
 
             // If no map/status yet, maybe it's just starting
             let text = `🟢 *${escapeMarkdown(displayName)}* is playing Counter-Strike`;
-            if (map || status || score) text += `\n`;
+            if (map || status || score || rounds.length > 0) text += `\n`;
             if (map) text += `\nMap: ${escapeMarkdown(map)}`;
             if (status) text += `\nStatus: ${escapeMarkdown(status)}`;
             if (score) text += `\nScore: ${escapeMarkdown(score)}`;
+            if (rounds.length > 0) text += `\nRounds: ${this.formatRounds(rounds)}`;
 
             console.debug(`Publishing update for user ${tgUserId} to chat ${chatId}`);
             await this.publishUpdate(chatId, tgUserId, text, info);
@@ -429,15 +438,26 @@ class SteamService {
     async publishUpdate(chatId: number, tgUserId: number, text: string, info: GameUpdateInfo): Promise<void> {
         try {
             const lastUpdate: GameUpdate = await this.gameUpdateDao.getGameUpdate(chatId, tgUserId);
-            
+
+            const now = new Date();
+            const sixHoursAgo = new Date(now.getTime() - 6 * 60 * 60 * 1000);
+
+            // The live message doubles as the session's scoreboard: matches that finished during
+            // its lifetime are listed above the current game state. A fresh message starts a
+            // fresh session, so it carries no overview.
+            if (lastUpdate && new Date(lastUpdate.timestamp) > sixHoursAgo) {
+                const sessionStart = new Date(new Date(lastUpdate.timestamp).getTime() - SESSION_OVERVIEW_SLACK_MS);
+                const sessionMatches = await this.gameHistoryDao.getGameHistorySince(chatId, tgUserId, sessionStart);
+                if (sessionMatches.length > 0) {
+                    text = `${sessionMatches.map(m => this.sessionOverviewLine(m)).join('\n')}\n\n${text}`;
+                }
+            }
+
             // Avoid redundant updates
             if (lastUpdate && lastUpdate.text === text) {
                 console.log(`Update for user ${tgUserId} in chat ${chatId} is redundant (text hasn't changed), skipping.`);
                 return;
             }
-
-            const now = new Date();
-            const sixHoursAgo = new Date(now.getTime() - 6 * 60 * 60 * 1000);
 
             if (lastUpdate && new Date(lastUpdate.timestamp) > sixHoursAgo) {
                 const oldInfo: GameUpdateInfo = lastUpdate.info || {};
@@ -536,6 +556,46 @@ class SteamService {
     // Parse a raw "16-14" (or "16:14") score into its parts and round total.
     parseRawScore(score?: string): { a: number; b: number; total: number } | null {
         return parseRawScoreFn(score);
+    }
+
+    // One session-overview line: "🏆 Competitive: Vertigo 1️⃣3️⃣:8️⃣". The score keeps the raw
+    // player-opponent order but is rendered with a colon so it can't be mistaken for the raw
+    // "13-8" form used elsewhere.
+    sessionOverviewLine(match: SessionMatch): string {
+        const parts: string[] = [this.resultEmoji(match.score)];
+        if (match.mode) parts.push(`${escapeMarkdown(match.mode)}:`);
+        if (match.map) parts.push(escapeMarkdown(match.map));
+        const parsed = this.parseRawScore(match.score);
+        if (parsed) parts.push(this.formatScore(`${parsed.a}:${parsed.b}`));
+        return parts.join(' ');
+    }
+
+    // 🎖️ per round won, ☠️ per round lost, e.g. "🎖️☠️🎖️🎖️".
+    formatRounds(rounds: RoundOutcome[]): string {
+        return rounds.map(r => r === 'win' ? '🎖️' : '☠️').join('');
+    }
+
+    // Per-round outcomes of the account's current (unfinalised) match, replayed from the
+    // stream's open segment under its lock so a concurrent append or finalisation can't be
+    // observed halfway. Returns [] (also on error) — the live message just omits the line.
+    private getLiveRounds(steamId: string): Promise<RoundOutcome[]> {
+        return this.withStreamLock(steamId, async () => {
+            try {
+                const cursor = await this.presenceEventDao.getCursor(steamId);
+                const events = await this.presenceEventDao.getEventsAfter(steamId, cursor);
+                if (events.length === 0) {
+                    return [];
+                }
+                // A pending (unconfirmed) reset holds the newest observations — including the
+                // score the live message is showing — so its rounds are the ones to render.
+                const { open, pending } = segmentStream(events, new Date(), DERIVATION_CONFIG);
+                const current = pending ?? open;
+                return current ? deriveRounds(current.events) : [];
+            } catch (err) {
+                console.error(`Error deriving live rounds for Steam ID ${steamId}:`, err);
+                return [];
+            }
+        });
     }
 
     // 🏆/☠️/🤝 from a raw score (first part = player, second = opponents).
@@ -939,12 +999,14 @@ class SteamService {
 
             let newText = lastUpdate.text;
 
-            // Check if already closed
-            if (newText.startsWith('🔴')) {
+            // Check if already closed. The 🟢/🔴 marker sits on the current-state line, which is
+            // no longer necessarily the first one (the session overview renders above it), so
+            // look anywhere in the text rather than at the start.
+            if (newText.includes('🔴')) {
                 return;
             }
 
-            if (newText.startsWith('🟢')) {
+            if (newText.includes('🟢')) {
                 newText = newText.replace('🟢', '🔴');
             } else {
                 // Legacy or unexpected format, prepend red

--- a/acceptance/features/delete_match_record.feature
+++ b/acceptance/features/delete_match_record.feature
@@ -1,0 +1,42 @@
+Feature: deleting match records
+  The admin (STEAM_ADMIN_TELEGRAM_USER_ID, 9999 in this suite) can remove a mis-recorded
+  match from a player's game history via /delete_match_record and an inline picker.
+  Everyone else is refused.
+
+  Scenario: the admin deletes a mis-recorded match record
+    Given a chat with id 2301
+    And a user with id 6101 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000001101"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000001101"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000001101" playing CS2 as "Alpha" with score "13-7" on map "Vertigo"
+    And Steam reports user "76561198000001101" stopped playing
+    Then chat 2301 eventually receives a new Steam message containing "won a game"
+    When user 9999 sends "/delete_match_record Alpha"
+    Then the bot reply contains "Select the match record to delete"
+    When user 9999 named "Admin" taps the button containing "13-7"
+    Then the Steam message in chat 2301 is edited to contain "Deleted match record"
+    When the user sends "/game_history"
+    Then the bot replies "No game history yet."
+
+  Scenario: a non-admin cannot delete match records
+    Given a chat with id 2302
+    And a user with id 6102 and first name "Tester"
+    When the user sends "/delete_match_record"
+    Then the bot reply contains "Only the admin can delete match records"
+
+  Scenario: a non-admin tapping the picker is refused
+    Given a chat with id 2303
+    And a user with id 6103 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000001103"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000001103"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000001103" playing CS2 as "Bravo" with score "13-7" on map "Nuke"
+    And Steam reports user "76561198000001103" stopped playing
+    Then chat 2303 eventually receives a new Steam message containing "won a game"
+    When user 9999 sends "/delete_match_record Bravo"
+    Then the bot reply contains "Select the match record to delete"
+    When user 6103 named "Tester" taps the button containing "13-7"
+    Then the tap is answered with "Only the admin can delete match records."
+    When the user sends "/game_history"
+    Then the bot reply contains "13-7"

--- a/acceptance/features/steam_game_updates.feature
+++ b/acceptance/features/steam_game_updates.feature
@@ -39,6 +39,32 @@ Feature: Steam game-presence updates
     And Steam reports user "76561198000000040" playing CS2 with no details
     Then the latest Steam message in chat 2004 still contains "🟢"
 
+  Scenario: round outcomes are tracked in the live message
+    Given a chat with id 2005
+    And a user with id 5905 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000050"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000050"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000050" playing CS2 with score "1-0" on map "Inferno"
+    Then chat 2005 receives a Steam message containing "Rounds: 🎖️"
+    When a moment passes
+    And Steam reports user "76561198000000050" playing CS2 with score "1-1" on map "Inferno"
+    Then the Steam message in chat 2005 is edited to contain "Rounds: 🎖️☠️"
+
+  Scenario: a finished match is listed above the live game state for the session
+    Given a chat with id 2006
+    And a user with id 5906 and first name "Tester"
+    When the user sends "/steam_user_id 76561198000000060"
+    Then the bot replies "Your Steam user ID(s) has been set to 76561198000000060"
+    When Steam mappings are refreshed
+    And Steam reports user "76561198000000060" playing CS2 with score "13-8" on map "Vertigo"
+    Then chat 2006 receives a Steam message containing "is playing Counter-Strike"
+    When a moment passes
+    And Steam reports user "76561198000000060" playing CS2 with score "1-0" on map "Vertigo"
+    And a moment passes
+    And Steam reports user "76561198000000060" playing CS2 with score "2-0" on map "Vertigo"
+    Then the Steam message in chat 2006 is edited to contain "🏆 Competitive: Vertigo 1️⃣3️⃣:8️⃣"
+
   Scenario: a chat that disabled updates receives nothing
     Given a chat with id 2002
     And a user with id 5902 and first name "Tester"

--- a/acceptance/features/steps/telegram_steps.py
+++ b/acceptance/features/steps/telegram_steps.py
@@ -168,6 +168,30 @@ def step_user_taps(context: Context, user_id: str, name: str, choice: str) -> No
     helpers.inject_callback(f"rsvp:{choice}", context.chat_id, user, message_id)
 
 
+@when('user (?P<user_id>\\d+) named "(?P<name>[^"]*)" taps the button containing "(?P<needle>[^"]*)"')
+def step_user_taps_button_containing(context: Context, user_id: str, name: str, needle: str) -> None:
+    """Tap the first inline button whose label contains `needle`, searching newest message first."""
+    outbox: List[Dict[str, Any]] = helpers.get_outbox(context.chat_id)
+    for message in reversed(outbox):
+        markup: Dict[str, Any] = helpers.reply_markup(message)
+        for row in markup.get("inline_keyboard", []):
+            for button in row:
+                if needle in (button.get("text") or ""):
+                    context.cmd_chat = context.chat_id
+                    context.cmd_baseline = len(helpers.get_outbox(context.chat_id))
+                    context.cb_baseline = len(helpers.get_callback_answers())
+                    user: Dict[str, Any] = {
+                        "id": int(user_id), "first_name": name, "username": name.lower()
+                    }
+                    helpers.inject_callback(
+                        button["callback_data"], context.chat_id, user, message["message_id"]
+                    )
+                    return
+    raise AssertionError(
+        f"No inline button containing {needle!r} found in chat {context.chat_id}"
+    )
+
+
 @then('the tap is answered with "(?P<expected>[^"]*)"')
 def step_tap_answered_with(context: Context, expected: str) -> None:
     answers: List[Dict[str, Any]] = helpers.wait_for_callback_answer(context.cb_baseline)

--- a/command/admin/delete_match_record.ts
+++ b/command/admin/delete_match_record.ts
@@ -8,12 +8,13 @@ import { resultEmoji } from '../game_history.js';
 
 const dao = new GameHistoryDAO();
 
-// How many of the player's most recent matches to offer for deletion. Telegram keyboards get
-// unwieldy beyond this, and a mis-recorded match is virtually always a recent one.
-const MAX_CHOICES = 10;
+// Match records offered per picker page. The keyboard paginates through the player's entire
+// history (newest first), so a mis-recorded match from weeks back is still reachable.
+export const PAGE_SIZE = 10;
 
 // The callback-data namespace for the deletion keyboard, dispatched to handleDeleteMatchCallback
-// by the main callback_query listener.
+// by the main callback_query listener. Payloads: "<id>" deletes a record, "page:<uid>:<offset>"
+// re-renders the keyboard at another offset, "noop" is the inert page indicator, "cancel" closes.
 export const CALLBACK_PREFIX = 'delmatch:';
 
 // Only the configured Steam admin may delete match records.
@@ -35,7 +36,46 @@ const describeEntry = (entry: GameHistoryEntry): string => {
 // Button label: the match description plus when it ended, so look-alike matches can be told apart.
 const buttonLabel = (entry: GameHistoryEntry): string => {
     const ended = DateTime.fromJSDate(new Date(entry.ended_at), { zone: 'utc' });
-    return `${describeEntry(entry)} · ${ended.toFormat('d MMM HH:mm')} UTC`;
+    return `${describeEntry(entry)} · ${ended.toFormat('d MMM yyyy HH:mm')} UTC`;
+};
+
+// Build the picker keyboard for one page of records (newest first). Pure so the pagination
+// shape is unit-testable: one row per record, a navigation row when the history spans more
+// than one page ("Newer" towards offset 0, "Older" towards the end), and a Cancel row.
+export const pickerKeyboard = (
+    entries: GameHistoryEntry[],
+    targetUserId: number,
+    total: number,
+    offset: number
+): InlineKeyboardButton[][] => {
+    const keyboard: InlineKeyboardButton[][] = entries.map(entry => ([{
+        text: buttonLabel(entry),
+        callback_data: `${CALLBACK_PREFIX}${entry.id}`
+    }]));
+
+    if (total > PAGE_SIZE) {
+        const nav: InlineKeyboardButton[] = [];
+        if (offset > 0) {
+            nav.push({
+                text: '⬅️ Newer',
+                callback_data: `${CALLBACK_PREFIX}page:${targetUserId}:${Math.max(0, offset - PAGE_SIZE)}`
+            });
+        }
+        nav.push({
+            text: `${Math.floor(offset / PAGE_SIZE) + 1}/${Math.ceil(total / PAGE_SIZE)}`,
+            callback_data: `${CALLBACK_PREFIX}noop`
+        });
+        if (offset + PAGE_SIZE < total) {
+            nav.push({
+                text: 'Older ➡️',
+                callback_data: `${CALLBACK_PREFIX}page:${targetUserId}:${offset + PAGE_SIZE}`
+            });
+        }
+        keyboard.push(nav);
+    }
+
+    keyboard.push([{ text: '✖️ Cancel', callback_data: `${CALLBACK_PREFIX}cancel` }]);
+    return keyboard;
 };
 
 export default (bot: TelegramBot, msg: ExtendedMessage): void => {
@@ -47,35 +87,31 @@ export default (bot: TelegramBot, msg: ExtendedMessage): void => {
     resolvePlayerTarget(dao, msg)
         .then(target => {
             if (!target) return;  // resolvePlayerTarget already replied with the reason.
-            return dao.getGameHistory(msg.chat.id, target.user_id)
-                .then((entries: GameHistoryEntry[]) => {
-                    if (entries.length === 0) {
+            return dao.getGameHistoryPage(msg.chat.id, target.user_id, 0, PAGE_SIZE)
+                .then(({ total, entries }) => {
+                    if (total === 0) {
                         msg.reply(target.name
                             ? `No match records for ${escapeMarkdown(target.name)} in this chat.`
                             : 'No match records for you in this chat.');
                         return;
                     }
 
-                    // Most recent first; entries come back oldest first.
-                    const recent = entries.slice(-MAX_CHOICES).reverse();
-                    const keyboard: InlineKeyboardButton[][] = recent.map(entry => ([{
-                        text: buttonLabel(entry),
-                        callback_data: `${CALLBACK_PREFIX}${entry.id}`
-                    }]));
-                    keyboard.push([{ text: '✖️ Cancel', callback_data: `${CALLBACK_PREFIX}cancel` }]);
-
                     const who = target.name ? ` for *${escapeMarkdown(target.name)}*` : '';
                     return bot.sendMessage(msg.chat.id,
-                        `Select the match record to delete${who}:`,
-                        { parse_mode: 'Markdown', reply_markup: { inline_keyboard: keyboard } });
+                        `Select the match record to delete${who} (${total} recorded):`,
+                        {
+                            parse_mode: 'Markdown',
+                            reply_markup: { inline_keyboard: pickerKeyboard(entries, target.user_id, total, 0) }
+                        });
                 });
         })
         .catch((err: Error) => msg.reply(formatError(err)));
 };
 
 // Handle a tap on the deletion keyboard. Re-checks the admin gate (buttons are visible to the
-// whole chat) and that the record still exists and belongs to the chat the button lives in,
-// then deletes it and replaces the picker with a confirmation.
+// whole chat); page taps re-render the keyboard at the requested offset, record taps verify the
+// record still exists and belongs to the chat the button lives in, then delete it and replace
+// the picker with a confirmation.
 export const handleDeleteMatchCallback = (bot: TelegramBot, query: CallbackQuery): void => {
     const data = query.data;
     const message = query.message;
@@ -92,14 +128,50 @@ export const handleDeleteMatchCallback = (bot: TelegramBot, query: CallbackQuery
             parse_mode: 'Markdown'
         }).catch((err: Error) => console.error(`Failed to edit match-deletion message ${message.message_id}:`, err));
 
+    const arg = data.substring(CALLBACK_PREFIX.length);
+
+    if (arg === 'noop') {
+        answer();
+        return;
+    }
+
     if (!isAdmin(query.from?.id)) {
         answer('Only the admin can delete match records.');
         return;
     }
 
-    const arg = data.substring(CALLBACK_PREFIX.length);
     if (arg === 'cancel') {
         replacePicker('Match record deletion cancelled.').then(() => answer());
+        return;
+    }
+
+    const pageMatch = arg.match(/^page:(-?\d+):(\d+)$/);
+    if (pageMatch) {
+        const targetUserId = Number(pageMatch[1]);
+        const offset = Number(pageMatch[2]);
+        // A tap that lands on an unchanged keyboard (e.g. a double-tap) is not an error.
+        const updateKeyboard = (entries: GameHistoryEntry[], total: number, at: number): Promise<unknown> =>
+            bot.editMessageReplyMarkup(
+                { inline_keyboard: pickerKeyboard(entries, targetUserId, total, at) },
+                { chat_id: message.chat.id, message_id: message.message_id }
+            ).catch((err: Error) => {
+                if (!err.message?.includes('message is not modified')) throw err;
+            });
+        dao.getGameHistoryPage(message.chat.id, targetUserId, offset, PAGE_SIZE)
+            .then(({ total, entries }) => {
+                if (entries.length === 0) {
+                    // The last record of this page was deleted meanwhile; fall back to page 1.
+                    return dao.getGameHistoryPage(message.chat.id, targetUserId, 0, PAGE_SIZE)
+                        .then(first => first.total === 0
+                            ? replacePicker('No match records left.').then(() => answer())
+                            : updateKeyboard(first.entries, first.total, 0).then(() => answer()));
+                }
+                return updateKeyboard(entries, total, offset).then(() => answer());
+            })
+            .catch((err: Error) => {
+                console.error(`Error paging match records for user ${targetUserId}:`, err);
+                answer('Something went wrong.');
+            });
         return;
     }
 

--- a/command/admin/delete_match_record.ts
+++ b/command/admin/delete_match_record.ts
@@ -1,0 +1,130 @@
+import TelegramBot, { CallbackQuery, InlineKeyboardButton } from 'node-telegram-bot-api';
+import { DateTime } from 'luxon';
+import { ExtendedMessage } from '../../MessageRouter.js';
+import GameHistoryDAO, { GameHistoryEntry } from '../../dao/GameHistoryDAO.js';
+import { escapeMarkdown, formatError } from '../../utils.js';
+import { resolvePlayerTarget } from '../playerArg.js';
+import { resultEmoji } from '../game_history.js';
+
+const dao = new GameHistoryDAO();
+
+// How many of the player's most recent matches to offer for deletion. Telegram keyboards get
+// unwieldy beyond this, and a mis-recorded match is virtually always a recent one.
+const MAX_CHOICES = 10;
+
+// The callback-data namespace for the deletion keyboard, dispatched to handleDeleteMatchCallback
+// by the main callback_query listener.
+export const CALLBACK_PREFIX = 'delmatch:';
+
+// Only the configured Steam admin may delete match records.
+const isAdmin = (userId?: number): boolean => {
+    const admin = process.env.STEAM_ADMIN_TELEGRAM_USER_ID;
+    return !!admin && userId != null && String(userId) === admin;
+};
+
+// Plain-text description of a match record for button labels and confirmations,
+// e.g. "🏆 Vertigo · Competitive · 13-7".
+const describeEntry = (entry: GameHistoryEntry): string => {
+    const parts: string[] = [];
+    if (entry.map) parts.push(entry.map);
+    if (entry.mode) parts.push(entry.mode);
+    if (entry.score) parts.push(entry.score);
+    return `${resultEmoji(entry.score)} ${parts.join(' · ') || 'unknown match'}`;
+};
+
+// Button label: the match description plus when it ended, so look-alike matches can be told apart.
+const buttonLabel = (entry: GameHistoryEntry): string => {
+    const ended = DateTime.fromJSDate(new Date(entry.ended_at), { zone: 'utc' });
+    return `${describeEntry(entry)} · ${ended.toFormat('d MMM HH:mm')} UTC`;
+};
+
+export default (bot: TelegramBot, msg: ExtendedMessage): void => {
+    if (!isAdmin(msg.from?.id)) {
+        msg.reply('Only the admin can delete match records.');
+        return;
+    }
+
+    resolvePlayerTarget(dao, msg)
+        .then(target => {
+            if (!target) return;  // resolvePlayerTarget already replied with the reason.
+            return dao.getGameHistory(msg.chat.id, target.user_id)
+                .then((entries: GameHistoryEntry[]) => {
+                    if (entries.length === 0) {
+                        msg.reply(target.name
+                            ? `No match records for ${escapeMarkdown(target.name)} in this chat.`
+                            : 'No match records for you in this chat.');
+                        return;
+                    }
+
+                    // Most recent first; entries come back oldest first.
+                    const recent = entries.slice(-MAX_CHOICES).reverse();
+                    const keyboard: InlineKeyboardButton[][] = recent.map(entry => ([{
+                        text: buttonLabel(entry),
+                        callback_data: `${CALLBACK_PREFIX}${entry.id}`
+                    }]));
+                    keyboard.push([{ text: '✖️ Cancel', callback_data: `${CALLBACK_PREFIX}cancel` }]);
+
+                    const who = target.name ? ` for *${escapeMarkdown(target.name)}*` : '';
+                    return bot.sendMessage(msg.chat.id,
+                        `Select the match record to delete${who}:`,
+                        { parse_mode: 'Markdown', reply_markup: { inline_keyboard: keyboard } });
+                });
+        })
+        .catch((err: Error) => msg.reply(formatError(err)));
+};
+
+// Handle a tap on the deletion keyboard. Re-checks the admin gate (buttons are visible to the
+// whole chat) and that the record still exists and belongs to the chat the button lives in,
+// then deletes it and replaces the picker with a confirmation.
+export const handleDeleteMatchCallback = (bot: TelegramBot, query: CallbackQuery): void => {
+    const data = query.data;
+    const message = query.message;
+    if (!data || !data.startsWith(CALLBACK_PREFIX) || !message) {
+        return;
+    }
+
+    const answer = (text?: string): Promise<unknown> =>
+        bot.answerCallbackQuery(query.id, text ? { text } : {}).catch(() => undefined);
+    const replacePicker = (text: string): Promise<unknown> =>
+        bot.editMessageText(text, {
+            chat_id: message.chat.id,
+            message_id: message.message_id,
+            parse_mode: 'Markdown'
+        }).catch((err: Error) => console.error(`Failed to edit match-deletion message ${message.message_id}:`, err));
+
+    if (!isAdmin(query.from?.id)) {
+        answer('Only the admin can delete match records.');
+        return;
+    }
+
+    const arg = data.substring(CALLBACK_PREFIX.length);
+    if (arg === 'cancel') {
+        replacePicker('Match record deletion cancelled.').then(() => answer());
+        return;
+    }
+
+    const id = Number(arg);
+    if (!Number.isInteger(id)) {
+        answer();
+        return;
+    }
+
+    dao.getGameHistoryEntryById(id)
+        .then(entry => {
+            if (!entry || entry.chat_id !== message.chat.id) {
+                return replacePicker('That match record no longer exists.').then(() => answer());
+            }
+            return dao.deleteGameHistoryEntry(id).then(deleted => {
+                if (!deleted) {
+                    return replacePicker('That match record no longer exists.').then(() => answer());
+                }
+                const who = entry.player_name ? ` (${escapeMarkdown(entry.player_name)})` : '';
+                return replacePicker(`🗑️ Deleted match record: ${escapeMarkdown(describeEntry(entry))}${who}`)
+                    .then(() => answer('Match record deleted.'));
+            });
+        })
+        .catch((err: Error) => {
+            console.error(`Error deleting match record ${id}:`, err);
+            answer('Something went wrong.');
+        });
+};

--- a/command/game_history.ts
+++ b/command/game_history.ts
@@ -26,7 +26,7 @@ export const scoreResult = (score?: string): GameResult | null => {
     return 'tie';
 };
 
-const resultEmoji = (score?: string): string => {
+export const resultEmoji = (score?: string): string => {
     switch (scoreResult(score)) {
         case 'win': return '🏆';
         case 'loss': return '☠️';

--- a/dao/GameHistoryDAO.ts
+++ b/dao/GameHistoryDAO.ts
@@ -223,6 +223,40 @@ class GameHistoryDAO {
         return order.map(id => byId.get(id)!);
     }
 
+    // One page of a player's match records in a chat, newest first (no co-players — used by
+    // the /delete_match_record picker), plus the total count so the picker can paginate.
+    async getGameHistoryPage(chat_id: number, user_id: number, offset: number, limit: number): Promise<{ total: number; entries: GameHistoryEntry[] }> {
+        const countRows = await query<RowDataPacket[]>(
+            'SELECT COUNT(*) AS total FROM game_history WHERE chat_id = :chat_id AND user_id = :user_id',
+            { chat_id, user_id }
+        );
+        const total = Number(countRows[0].total);
+        if (total === 0) {
+            return { total, entries: [] };
+        }
+        const rows = await query<RowDataPacket[]>(
+            'SELECT id, chat_id, user_id, player_name, mode, map, score, started_at, ended_at ' +
+            'FROM game_history WHERE chat_id = :chat_id AND user_id = :user_id ' +
+            'ORDER BY id DESC LIMIT :limit OFFSET :offset',
+            { chat_id, user_id, limit, offset }
+        );
+        return {
+            total,
+            entries: rows.map(row => ({
+                id: Number(row.id),
+                chat_id: Number(row.chat_id),
+                user_id: Number(row.user_id),
+                player_name: row.player_name ?? undefined,
+                mode: row.mode ?? undefined,
+                map: row.map ?? undefined,
+                score: row.score ?? undefined,
+                co_players: [],
+                started_at: row.started_at ?? undefined,
+                ended_at: row.ended_at
+            }))
+        };
+    }
+
     // A single match record by id (no co-players — used to describe and verify a record
     // before deleting it), or null if it doesn't exist.
     async getGameHistoryEntryById(id: number): Promise<GameHistoryEntry | null> {

--- a/dao/GameHistoryDAO.ts
+++ b/dao/GameHistoryDAO.ts
@@ -17,6 +17,7 @@ export interface ChatPlayer {
 }
 
 export interface GameHistoryEntry {
+    id?: number;           // set on entries read back from the database
     chat_id: number;
     user_id: number;
     player_name?: string;  // owner's resolved display name at match end, for grouped announcements
@@ -26,6 +27,13 @@ export interface GameHistoryEntry {
     co_players: GameHistoryCoPlayer[];
     started_at?: Date;
     ended_at: Date;
+}
+
+// A finished match in the compact form the live message's session overview renders.
+export interface SessionMatch {
+    mode?: string;
+    map?: string;
+    score?: string;
 }
 
 // A recently-finished match used for grouping a per-match end-of-game announcement: the owner (with
@@ -67,6 +75,7 @@ class GameHistoryDAO {
             let entry = byId.get(id);
             if (!entry) {
                 entry = {
+                    id,
                     chat_id: Number(row.chat_id),
                     user_id: Number(row.user_id),
                     mode: row.mode ?? undefined,
@@ -85,6 +94,22 @@ class GameHistoryDAO {
             }
         }
         return order.map(id => byId.get(id)!);
+    }
+
+    // The player's matches that finished during the current play session (ended at or after
+    // `since`), oldest first — the live message's session overview.
+    async getGameHistorySince(chat_id: number, user_id: number, since: Date): Promise<SessionMatch[]> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT mode, map, score FROM game_history ' +
+            'WHERE chat_id = :chat_id AND user_id = :user_id AND ended_at >= :since ' +
+            'ORDER BY id ASC',
+            { chat_id, user_id, since }
+        );
+        return rows.map(row => ({
+            mode: row.mode ?? undefined,
+            map: row.map ?? undefined,
+            score: row.score ?? undefined
+        }));
     }
 
     // Distinct players with recorded game history in a chat. `name` is the player's most recent
@@ -196,6 +221,41 @@ class GameHistoryDAO {
             }
         }
         return order.map(id => byId.get(id)!);
+    }
+
+    // A single match record by id (no co-players — used to describe and verify a record
+    // before deleting it), or null if it doesn't exist.
+    async getGameHistoryEntryById(id: number): Promise<GameHistoryEntry | null> {
+        const rows = await query<RowDataPacket[]>(
+            'SELECT id, chat_id, user_id, player_name, mode, map, score, started_at, ended_at ' +
+            'FROM game_history WHERE id = :id',
+            { id }
+        );
+        if (rows.length === 0) {
+            return null;
+        }
+        const row = rows[0];
+        return {
+            id: Number(row.id),
+            chat_id: Number(row.chat_id),
+            user_id: Number(row.user_id),
+            player_name: row.player_name ?? undefined,
+            mode: row.mode ?? undefined,
+            map: row.map ?? undefined,
+            score: row.score ?? undefined,
+            co_players: [],
+            started_at: row.started_at ?? undefined,
+            ended_at: row.ended_at
+        };
+    }
+
+    // Delete a match record (its co-player rows cascade). Returns whether a row was deleted.
+    async deleteGameHistoryEntry(id: number): Promise<boolean> {
+        const res = await query<ResultSetHeader>(
+            'DELETE FROM game_history WHERE id = :id',
+            { id }
+        );
+        return res.affectedRows > 0;
     }
 
     setGameHistoryMessageId(id: number, message_id: number): Promise<void> {

--- a/main.ts
+++ b/main.ts
@@ -31,6 +31,7 @@ import steamGuardHandler from './command/steam_guard.js';
 import gameHistoryHandler from './command/game_history.js';
 import statsHandler from './command/stats.js';
 import githubNotifyHandler from './command/github_notify.js';
+import deleteMatchRecordHandler, { handleDeleteMatchCallback, CALLBACK_PREFIX as DELETE_MATCH_CALLBACK_PREFIX } from './command/admin/delete_match_record.js';
 import rollcallAddPlayerHandler from './command/admin/rollcall_add_player.js';
 import rollcallRemovePlayerHandler from './command/admin/rollcall_remove_player.js';
 import rollcallGetPlayersHandler from './command/admin/rollcall_get_players.js';
@@ -214,6 +215,9 @@ if (steamEnabled) {
     router.route('stats', statsHandler, {
         helpText: 'Show competitive CS2 stats for this chat: win rate, streaks, maps. Add a player name or mention to see theirs.'
     });
+    router.route('delete_match_record', deleteMatchRecordHandler, {
+        helpText: 'Admin only: delete a mis-recorded match from a player\'s game history.'
+    });
 }
 
 router.route('help', (bot: TelegramBot, msg: ExtendedMessage) => {
@@ -261,6 +265,10 @@ bot.on('message', (msg: Message) => {
 });
 
 bot.on('callback_query', (query: CallbackQuery) => {
+    if (query.data?.startsWith(DELETE_MATCH_CALLBACK_PREFIX)) {
+        handleDeleteMatchCallback(bot, query);
+        return;
+    }
     handleRsvpCallback(query);
 });
 

--- a/matchDerivation.ts
+++ b/matchDerivation.ts
@@ -61,6 +61,10 @@ export interface MatchSegment {
 export interface StreamDerivation {
     closed: MatchSegment[];    // finished matches, oldest first
     open: MatchSegment | null; // the still-live segment, if any
+    // A provisional post-reset segment not yet confirmed as a new match (nor refuted as a
+    // flake). While it exists, the most recent observations — including the score the live
+    // message is showing — belong to it rather than to `open`.
+    pending: MatchSegment | null;
 }
 
 // Parse a raw "16-14" (or "16:14") score into its parts and round total.
@@ -221,7 +225,31 @@ export const segmentStream = (events: PresenceEvent[], now: Date, config: Deriva
         open = null;
     }
 
-    return { closed, open };
+    return { closed, open, pending };
+};
+
+export type RoundOutcome = 'win' | 'loss';
+
+// Reconstruct a segment's per-round outcomes (player's perspective) by diffing consecutive
+// observed scores: 7-4 → 8-4 is a round won, 8-4 → 8-5 a round lost. Each side's tally only
+// ever moves up within a match, so an observation below the running maxima is dip/out-of-order
+// noise and is skipped — the same max-only stance absorb() takes for the segment score. When
+// several rounds pass between observations (missed ticks, or a stream that starts mid-match)
+// the totals are still right but the order within the gap is unknown; wins are emitted first.
+export const deriveRounds = (events: PresenceEvent[]): RoundOutcome[] => {
+    const rounds: RoundOutcome[] = [];
+    let a = 0;
+    let b = 0;
+    for (const e of events) {
+        const parsed = parseRawScore(e.raw_score);
+        if (!parsed) continue;
+        if (parsed.a < a || parsed.b < b) continue;
+        for (let i = a; i < parsed.a; i++) rounds.push('win');
+        for (let i = b; i < parsed.b; i++) rounds.push('loss');
+        a = parsed.a;
+        b = parsed.b;
+    }
+    return rounds;
 };
 
 export interface CoPlayer {

--- a/test/deleteMatchRecord.test.ts
+++ b/test/deleteMatchRecord.test.ts
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pickerKeyboard, PAGE_SIZE, CALLBACK_PREFIX } from '../command/admin/delete_match_record.js';
+import { GameHistoryEntry } from '../dao/GameHistoryDAO.js';
+
+const entry = (id: number): GameHistoryEntry => ({
+    id,
+    chat_id: 1,
+    user_id: 42,
+    map: 'Vertigo',
+    mode: 'Competitive',
+    score: '13-7',
+    co_players: [],
+    ended_at: new Date('2026-01-01T12:00:00.000Z')
+});
+
+const entries = (n: number, from = 1): GameHistoryEntry[] =>
+    Array.from({ length: n }, (_, i) => entry(from + i));
+
+const callbacks = (keyboard: ReturnType<typeof pickerKeyboard>): string[][] =>
+    keyboard.map(row => row.map(b => b.callback_data!));
+
+test('picker: a single page has no navigation row, only records and Cancel', () => {
+    const kb = pickerKeyboard(entries(3), 42, 3, 0);
+    assert.equal(kb.length, 4);  // 3 records + Cancel
+    assert.deepEqual(callbacks(kb), [
+        [`${CALLBACK_PREFIX}1`],
+        [`${CALLBACK_PREFIX}2`],
+        [`${CALLBACK_PREFIX}3`],
+        [`${CALLBACK_PREFIX}cancel`]
+    ]);
+});
+
+test('picker: the first of several pages offers Older but not Newer', () => {
+    const kb = pickerKeyboard(entries(PAGE_SIZE), 42, 25, 0);
+    const nav = kb[kb.length - 2];
+    assert.deepEqual(nav.map(b => b.callback_data), [
+        `${CALLBACK_PREFIX}noop`,
+        `${CALLBACK_PREFIX}page:42:${PAGE_SIZE}`
+    ]);
+    assert.equal(nav[0].text, '1/3');
+    assert.equal(nav[1].text, 'Older ➡️');
+});
+
+test('picker: a middle page offers both directions with the right offsets', () => {
+    const kb = pickerKeyboard(entries(PAGE_SIZE), 42, 25, PAGE_SIZE);
+    const nav = kb[kb.length - 2];
+    assert.deepEqual(nav.map(b => b.callback_data), [
+        `${CALLBACK_PREFIX}page:42:0`,
+        `${CALLBACK_PREFIX}noop`,
+        `${CALLBACK_PREFIX}page:42:${2 * PAGE_SIZE}`
+    ]);
+    assert.equal(nav[1].text, '2/3');
+});
+
+test('picker: the last page offers Newer but not Older', () => {
+    const kb = pickerKeyboard(entries(5), 42, 25, 2 * PAGE_SIZE);
+    const nav = kb[kb.length - 2];
+    assert.deepEqual(nav.map(b => b.callback_data), [
+        `${CALLBACK_PREFIX}page:42:${PAGE_SIZE}`,
+        `${CALLBACK_PREFIX}noop`
+    ]);
+    assert.equal(nav[1].text, '3/3');
+});
+
+test('picker: record buttons carry result, map, mode, score and an unambiguous date', () => {
+    const kb = pickerKeyboard(entries(1), 42, 1, 0);
+    assert.equal(kb[0][0].text, '🏆 Vertigo · Competitive · 13-7 · 1 Jan 2026 12:00 UTC');
+});

--- a/test/matchDerivation.test.ts
+++ b/test/matchDerivation.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-    segmentStream, findCoPlayers, parseRawScore,
+    segmentStream, findCoPlayers, deriveRounds, parseRawScore,
     PresenceEvent, DerivationConfig
 } from '../matchDerivation.js';
 
@@ -409,4 +409,56 @@ test('co-player: an observation older than the staleness bound does not count', 
     ];
     const cos = findCoPlayers(seg, new Map([['B', stale]]), config);
     assert.equal(cos.length, 0);
+});
+
+test('deriveRounds: consecutive score observations become per-round outcomes', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '1-0' }),
+        ev(60, { map: 'Inferno', score: '1-1' }),
+        ev(120, { map: 'Inferno', score: '2-1' }),
+        ev(180, { map: 'Inferno', score: '3-1' })
+    ];
+    assert.deepEqual(deriveRounds(events), ['win', 'loss', 'win', 'win']);
+});
+
+test('deriveRounds: a gap between observations still yields the right totals, wins first', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '1-0' }),
+        ev(60, { map: 'Inferno', score: '3-2' })  // two wins and two losses were missed
+    ];
+    assert.deepEqual(deriveRounds(events), ['win', 'win', 'win', 'loss', 'loss']);
+});
+
+test('deriveRounds: a stream starting mid-match backfills the opening score', () => {
+    nextId = 1;
+    assert.deepEqual(
+        deriveRounds([ev(0, { map: 'Inferno', score: '2-1' })]),
+        ['win', 'win', 'loss']
+    );
+});
+
+test('deriveRounds: a score dip is skipped as noise, not counted twice on recovery', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '5-3' }),
+        ev(60, { map: 'Inferno', score: '1-0' }),  // flaky dip
+        ev(120, { map: 'Inferno', score: '6-3' })
+    ];
+    assert.deepEqual(
+        deriveRounds(events),
+        ['win', 'win', 'win', 'win', 'win', 'loss', 'loss', 'loss', 'win']
+    );
+});
+
+test('deriveRounds: unscored events (relaunches, bare presence) are ignored', () => {
+    nextId = 1;
+    const events = [
+        ev(0, { map: 'Inferno', score: '1-0' }),
+        ev(30, { playing: false }),
+        ev(60, { map: 'Inferno' }),
+        ev(90, { map: 'Inferno', score: '1-1' })
+    ];
+    assert.deepEqual(deriveRounds(events), ['win', 'loss']);
 });


### PR DESCRIPTION
The auto-updating game message now shows per-round outcomes below the
current game state (🎖️ per round won, ☠️ per round lost), derived by
diffing consecutive score observations of the stream's current segment,
and lists matches finished during the live message's lifetime above the
game state (e.g. "🏆 Competitive: Vertigo 1️⃣3️⃣:8️⃣") as a session
scoreboard.

A new admin-only /delete_match_record <player> command offers the
player's most recent match records on an inline keyboard so the admin
can remove a mis-recorded match; the record (and its co-player rows)
is deleted and the picker replaced with a confirmation. Both the picker
command and the button taps are gated on STEAM_ADMIN_TELEGRAM_USER_ID.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XkfFe63D5bDpnEnRAPzxUT