### PR TITLE
Poll GitHub conditionally and back off when rate limited

### DIFF
--- a/GitHubService.ts
+++ b/GitHubService.ts
@@ -1,6 +1,7 @@
 import TelegramBot from 'node-telegram-bot-api';
 import GithubDAO from './dao/GithubDAO.js';
 import { escapeHtml } from './utils.js';
+import { isRateLimitRejection, lowQuotaWarning, rateLimitBackoffMs } from './githubRateLimit.js';
 
 interface GitHubCommit {
     sha: string;
@@ -17,6 +18,13 @@ interface GitHubCommit {
     } | null;
 }
 
+interface CommitsResponse {
+    commits: GitHubCommit[];
+    // The response's ETag, replayed on the next poll so an unchanged repo answers
+    // 304 — which GitHub does not charge against the primary rate limit.
+    etag: string | null;
+}
+
 const DEFAULT_REPO = 'RobinJ1995/totaleBlindheidBot';
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const DEFAULT_API_BASE = 'https://api.github.com';
@@ -28,6 +36,10 @@ class GitHubService {
     private apiBase: string;
     private intervalMs: number;
     private pollInterval: NodeJS.Timeout | null;
+    private etag: string | null;
+    private etagLoaded: boolean;
+    // Epoch ms before which GitHub asked us not to come back. 0 = free to poll.
+    private rateLimitedUntil: number;
 
     constructor(bot: TelegramBot) {
         this.bot = bot;
@@ -38,6 +50,9 @@ class GitHubService {
         const configured = Number(process.env.GITHUB_POLL_INTERVAL_MS);
         this.intervalMs = Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_INTERVAL_MS;
         this.pollInterval = null;
+        this.etag = null;
+        this.etagLoaded = false;
+        this.rateLimitedUntil = 0;
     }
 
     start(): void {
@@ -58,7 +73,14 @@ class GitHubService {
         }
     }
 
-    private async fetchCommits(): Promise<GitHubCommit[] | null> {
+    private async fetchCommits(): Promise<CommitsResponse | null> {
+        const now = Date.now();
+        if (now < this.rateLimitedUntil) {
+            // Still inside the window GitHub told us to sit out. Requests made now
+            // would be rejected and still count as used, keeping the bucket pinned.
+            return null;
+        }
+
         const headers: Record<string, string> = {
             'User-Agent': 'totaleBlindheidBot',
             'Accept': 'application/vnd.github+json'
@@ -66,23 +88,74 @@ class GitHubService {
         if (process.env.GITHUB_TOKEN) {
             headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
         }
+        if (this.etag) {
+            headers['If-None-Match'] = this.etag;
+        }
 
         const url = `${this.apiBase}/repos/${this.repo}/commits?per_page=20`;
         const res = await fetch(url, { headers });
-        if (!res.ok) {
-            console.error(`GitHub API request failed: ${res.status} ${res.statusText}`);
+
+        const warning = lowQuotaWarning(res.headers);
+        if (warning) {
+            console.warn(warning);
+        }
+
+        // Nothing changed since the last poll. Checked before res.ok, which is false
+        // for 304.
+        if (res.status === 304) {
             return null;
         }
 
+        if (!res.ok) {
+            if (isRateLimitRejection(res.status, res.headers)) {
+                const backoffMs = rateLimitBackoffMs(res.headers, Date.now());
+                this.rateLimitedUntil = Date.now() + backoffMs;
+                console.error(
+                    `GitHub API rate limit hit (${res.status}); pausing polls for ${Math.ceil(backoffMs / 1000)}s.`
+                );
+            } else {
+                console.error(`GitHub API request failed: ${res.status} ${res.statusText}`);
+            }
+            return null;
+        }
+
+        // A successful response means we're inside the budget again.
+        this.rateLimitedUntil = 0;
+
         const body = await res.json();
-        return Array.isArray(body) ? body as GitHubCommit[] : null;
+        if (!Array.isArray(body)) {
+            return null;
+        }
+
+        return { commits: body as GitHubCommit[], etag: res.headers.get('etag') };
+    }
+
+    /**
+     * Store the ETag only once the response it belongs to has been fully accounted
+     * for. Saving it earlier would mean a failure part-way through processing leaves
+     * us replaying an ETag for commits we never announced — and 304ing forever after.
+     */
+    private async rememberEtag(etag: string | null): Promise<void> {
+        if (!etag || etag === this.etag) {
+            return;
+        }
+        this.etag = etag;
+        await this.dao.setGithubEtag(etag);
     }
 
     private async pollAndNotify(): Promise<void> {
-        const commits = await this.fetchCommits();
-        if (!commits || commits.length === 0) {
+        if (!this.etagLoaded) {
+            // Persisted so a restart resumes conditional requests instead of spending
+            // a full request to relearn what it already knew.
+            this.etag = (await this.dao.getGithubEtag()) ?? null;
+            this.etagLoaded = true;
+        }
+
+        const response = await this.fetchCommits();
+        if (!response || response.commits.length === 0) {
             return;
         }
+        const { commits, etag } = response;
 
         // GitHub returns newest first.
         const newestSha = commits[0].sha;
@@ -91,12 +164,16 @@ class GitHubService {
         // First ever run: record the baseline without announcing historical commits.
         if (!lastSha) {
             await this.dao.setGithubLastSha(newestSha);
+            await this.rememberEtag(etag);
             console.log(`GitHub baseline established at ${newestSha}`);
             return;
         }
 
         if (newestSha === lastSha) {
-            return; // Nothing new.
+            // Nothing new, but this response is now the baseline the next conditional
+            // request compares against.
+            await this.rememberEtag(etag);
+            return;
         }
 
         // Collect commits newer than lastSha (newest-first slice up to the known SHA).
@@ -126,6 +203,7 @@ class GitHubService {
         }
 
         await this.dao.setGithubLastSha(newestSha);
+        await this.rememberEtag(etag);
     }
 
     private formatCommit(commit: GitHubCommit): string {

--- a/GitHubService.ts
+++ b/GitHubService.ts
@@ -40,6 +40,9 @@ class GitHubService {
     private etagLoaded: boolean;
     // Epoch ms before which GitHub asked us not to come back. 0 = free to poll.
     private rateLimitedUntil: number;
+    // Drives the escalating wait GitHub asks for when a rejection carries no timing
+    // headers. Reset by any response it actually serves.
+    private consecutiveRateLimits: number;
 
     constructor(bot: TelegramBot) {
         this.bot = bot;
@@ -53,6 +56,7 @@ class GitHubService {
         this.etag = null;
         this.etagLoaded = false;
         this.rateLimitedUntil = 0;
+        this.consecutiveRateLimits = 0;
     }
 
     start(): void {
@@ -73,7 +77,7 @@ class GitHubService {
         }
     }
 
-    private async fetchCommits(): Promise<CommitsResponse | null> {
+    private async fetchCommits(useConditionalRequest: boolean): Promise<CommitsResponse | null> {
         const now = Date.now();
         if (now < this.rateLimitedUntil) {
             // Still inside the window GitHub told us to sit out. Requests made now
@@ -88,7 +92,7 @@ class GitHubService {
         if (process.env.GITHUB_TOKEN) {
             headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
         }
-        if (this.etag) {
+        if (useConditionalRequest && this.etag) {
             headers['If-None-Match'] = this.etag;
         }
 
@@ -100,6 +104,13 @@ class GitHubService {
             console.warn(warning);
         }
 
+        // Anything GitHub actually served — 200 or 304 — means we're inside the
+        // budget again, so the escalating backoff starts over.
+        if (res.ok || res.status === 304) {
+            this.rateLimitedUntil = 0;
+            this.consecutiveRateLimits = 0;
+        }
+
         // Nothing changed since the last poll. Checked before res.ok, which is false
         // for 304.
         if (res.status === 304) {
@@ -107,8 +118,13 @@ class GitHubService {
         }
 
         if (!res.ok) {
-            if (isRateLimitRejection(res.status, res.headers)) {
-                const backoffMs = rateLimitBackoffMs(res.headers, Date.now());
+            // Secondary limits can arrive with no timing headers at all, identifiable
+            // only by the message body. Reading it is free here — the error path has
+            // no other use for it.
+            const errorBody = await res.text().catch(() => '');
+            if (isRateLimitRejection(res.status, res.headers, errorBody)) {
+                this.consecutiveRateLimits += 1;
+                const backoffMs = rateLimitBackoffMs(res.headers, Date.now(), this.consecutiveRateLimits);
                 this.rateLimitedUntil = Date.now() + backoffMs;
                 console.error(
                     `GitHub API rate limit hit (${res.status}); pausing polls for ${Math.ceil(backoffMs / 1000)}s.`
@@ -118,9 +134,6 @@ class GitHubService {
             }
             return null;
         }
-
-        // A successful response means we're inside the budget again.
-        this.rateLimitedUntil = 0;
 
         const body = await res.json();
         if (!Array.isArray(body)) {
@@ -151,7 +164,13 @@ class GitHubService {
             this.etagLoaded = true;
         }
 
-        const response = await this.fetchCommits();
+        const lastSha = await this.dao.getGithubLastSha();
+
+        // A conditional request is only meaningful once a baseline exists. With no
+        // baseline a 304 tells us nothing we can act on, and — since it carries no
+        // commits — would stop us ever establishing one, silently swallowing the
+        // next push. Ask unconditionally until there is a SHA to compare against.
+        const response = await this.fetchCommits(Boolean(lastSha));
         if (!response || response.commits.length === 0) {
             return;
         }
@@ -159,7 +178,6 @@ class GitHubService {
 
         // GitHub returns newest first.
         const newestSha = commits[0].sha;
-        const lastSha = await this.dao.getGithubLastSha();
 
         // First ever run: record the baseline without announcing historical commits.
         if (!lastSha) {

--- a/acceptance/features/github_notifications.feature
+++ b/acceptance/features/github_notifications.feature
@@ -33,3 +33,10 @@ Feature: GitHub commit notifications
     When GitHub rejects the next 2 requests with a rate limit and retry-after 2
     And a commit "l1m1ted" with message "Survived the rate limit" is pushed to GitHub
     Then chat 7003 receives a GitHub notification containing "Survived the rate limit"
+
+  # Kept last: a secondary limit carries no timing headers, so the bot falls back to
+  # a minutes-long wait that would starve any scenario running after it.
+  Scenario: a secondary rate limit with no timing headers also stops the polling
+    Given the bot has established its GitHub baseline
+    When GitHub rejects the next request with a secondary rate limit
+    Then the bot stops polling GitHub

--- a/acceptance/features/github_notifications.feature
+++ b/acceptance/features/github_notifications.feature
@@ -16,3 +16,20 @@ Feature: GitHub commit notifications
     And a user with id 5971 and first name "Tester"
     When a commit "deadbee" with message "Silent change" is pushed to GitHub
     Then no GitHub notification is posted to chat 7002
+
+  Scenario: polls with nothing new are conditional requests
+    # An unchanged repo must answer 304, which GitHub does not charge against the
+    # hourly rate limit — that is what keeps a 5-minute poller affordable.
+    Given the bot has established its GitHub baseline
+    When the GitHub request counters are reset
+    Then GitHub answers at least one poll with "304 Not Modified"
+
+  Scenario: a rate-limited poller backs off and still announces once it recovers
+    Given a chat with id 7003
+    And a user with id 5972 and first name "Tester"
+    And the bot has established its GitHub baseline
+    When the user sends "/github_notify on"
+    Then the bot replies "GitHub notifications for this chat have been turned on."
+    When GitHub rejects the next 2 requests with a rate limit and retry-after 2
+    And a commit "l1m1ted" with message "Survived the rate limit" is pushed to GitHub
+    Then chat 7003 receives a GitHub notification containing "Survived the rate limit"

--- a/acceptance/features/steps/github_steps.py
+++ b/acceptance/features/steps/github_steps.py
@@ -38,6 +38,18 @@ def step_github_rate_limit(context: Context, count: int, retry_after: int) -> No
     helpers.github_reject_requests(count, retry_after)
 
 
+@when('GitHub rejects the next request with a secondary rate limit')
+def step_github_secondary_limit(context: Context) -> None:
+    # A secondary limit may carry neither retry-after nor an exhausted counter, so
+    # the message body is the only thing identifying it.
+    helpers.github_reject_requests(1, secondary=True)
+
+
+@then('the bot stops polling GitHub')
+def step_github_polling_stopped(context: Context) -> None:
+    helpers.wait_for_github_polling_to_stop()
+
+
 @when('the GitHub request counters are reset')
 def step_github_reset_stats(context: Context) -> None:
     helpers.github_reset_stats()

--- a/acceptance/features/steps/github_steps.py
+++ b/acceptance/features/steps/github_steps.py
@@ -1,7 +1,7 @@
 """Steps for driving the mocked GitHub commit-notification flow."""
 from typing import Any, Dict, List
 
-from behave import when, then, use_step_matcher
+from behave import given, when, then, use_step_matcher
 from behave.runner import Context
 
 import helpers
@@ -25,6 +25,27 @@ def step_github_notified(context: Context, chat_id: int, expected: str) -> None:
     texts: List[str] = [m["text"] for m in new if m["method"] == "sendMessage"]
     assert any(expected in t for t in texts), \
         f"Expected a GitHub notification containing {expected!r}; got {texts!r}"
+
+
+@given('the bot has established its GitHub baseline')
+@when('the bot has established its GitHub baseline')
+def step_github_baseline(context: Context) -> None:
+    helpers.wait_for_github_baseline()
+
+
+@when('GitHub rejects the next {count:d} requests with a rate limit and retry-after {retry_after:d}')
+def step_github_rate_limit(context: Context, count: int, retry_after: int) -> None:
+    helpers.github_reject_requests(count, retry_after)
+
+
+@when('the GitHub request counters are reset')
+def step_github_reset_stats(context: Context) -> None:
+    helpers.github_reset_stats()
+
+
+@then('GitHub answers at least one poll with "304 Not Modified"')
+def step_github_conditional(context: Context) -> None:
+    helpers.wait_for_conditional_request()
 
 
 @then('no GitHub notification is posted to chat {chat_id:d}')

--- a/acceptance/features/steps/helpers.py
+++ b/acceptance/features/steps/helpers.py
@@ -289,14 +289,36 @@ def github_reset_stats() -> None:
     requests.post(f"{GITHUB_MOCK_URL}/test/reset-stats", timeout=5).raise_for_status()
 
 
-def github_reject_requests(count: int, retry_after: int) -> None:
+def github_reject_requests(count: int, retry_after: int = 1, secondary: bool = False) -> None:
     """Make the mock answer the next `count` commit requests with a rate-limit 403."""
     resp = requests.post(
         f"{GITHUB_MOCK_URL}/test/rate-limit",
-        json={"requests": count, "retry_after": retry_after},
+        json={"requests": count, "retry_after": retry_after, "secondary": secondary},
         timeout=5,
     )
     resp.raise_for_status()
+
+
+def wait_for_github_polling_to_stop(quiet_seconds: float = 3.0, timeout: Optional[float] = None) -> None:
+    """Wait until the mock has gone `quiet_seconds` without a single request.
+
+    The bot polls about once a second, so a gap several times that long only
+    happens if it has actually backed off rather than retrying on schedule.
+    """
+    deadline: float = time.time() + (timeout if timeout is not None else REPLY_TIMEOUT)
+    seen: int = github_stats()["total_requests"]
+    quiet_since: float = time.time()
+    while time.time() < deadline:
+        time.sleep(POLL_INTERVAL)
+        current: int = github_stats()["total_requests"]
+        if current != seen:
+            seen = current
+            quiet_since = time.time()
+        elif time.time() - quiet_since >= quiet_seconds:
+            return
+    raise AssertionError(
+        f"Bot kept polling GitHub; never went {quiet_seconds}s without a request"
+    )
 
 
 def wait_for_github_baseline(timeout: Optional[float] = None) -> str:

--- a/acceptance/features/steps/helpers.py
+++ b/acceptance/features/steps/helpers.py
@@ -277,3 +277,55 @@ def github_add_commit(sha: str, message: str) -> None:
         timeout=5,
     )
     resp.raise_for_status()
+
+
+def github_stats() -> Dict[str, int]:
+    resp = requests.get(f"{GITHUB_MOCK_URL}/test/stats", timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def github_reset_stats() -> None:
+    requests.post(f"{GITHUB_MOCK_URL}/test/reset-stats", timeout=5).raise_for_status()
+
+
+def github_reject_requests(count: int, retry_after: int) -> None:
+    """Make the mock answer the next `count` commit requests with a rate-limit 403."""
+    resp = requests.post(
+        f"{GITHUB_MOCK_URL}/test/rate-limit",
+        json={"requests": count, "retry_after": retry_after},
+        timeout=5,
+    )
+    resp.raise_for_status()
+
+
+def wait_for_github_baseline(timeout: Optional[float] = None) -> str:
+    """Wait until the bot has recorded a baseline SHA.
+
+    Scenarios that interfere with polling need this first: without a baseline, the
+    bot treats the next successful poll as the starting point and announces nothing.
+    """
+    deadline: float = time.time() + (timeout if timeout is not None else REPLY_TIMEOUT)
+    while time.time() < deadline:
+        conn = db_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT last_sha FROM github_state WHERE id = 1")
+                row = cur.fetchone()
+                if row and row[0]:
+                    return str(row[0])
+        finally:
+            conn.close()
+        time.sleep(POLL_INTERVAL)
+    raise AssertionError("Bot never established a GitHub baseline SHA")
+
+
+def wait_for_conditional_request(timeout: Optional[float] = None) -> int:
+    """Wait until the mock has answered at least one poll with a 304."""
+    deadline: float = time.time() + (timeout if timeout is not None else REPLY_TIMEOUT)
+    while time.time() < deadline:
+        hits: int = github_stats()["conditional_hits"]
+        if hits > 0:
+            return hits
+        time.sleep(POLL_INTERVAL)
+    raise AssertionError("Bot never made a conditional request the mock could answer 304")

--- a/acceptance/github_mock/server.py
+++ b/acceptance/github_mock/server.py
@@ -43,9 +43,12 @@ _total_requests: int = 0
 _conditional_hits: int = 0
 
 # When set, the next _reject_requests commit requests answer with a rate-limit
-# rejection carrying this retry-after (seconds).
+# rejection carrying this retry-after (seconds). In "secondary" mode the rejection
+# carries no timing headers at all, which GitHub documents for secondary limits —
+# the client has only the message body to go on.
 _reject_requests: int = 0
 _reject_retry_after: int = 1
+_reject_secondary: bool = False
 
 
 def _etag() -> str:
@@ -60,6 +63,12 @@ def commits(owner: str, repo: str) -> Response:
 
         if _reject_requests > 0:
             _reject_requests -= 1
+            if _reject_secondary:
+                return Response(
+                    response='{"message": "You have exceeded a secondary rate limit."}',
+                    status=403,
+                    content_type="application/json",
+                )
             # Shape of a real primary rate-limit rejection: exhausted counter plus a
             # retry-after telling the client when to come back.
             return Response(
@@ -109,11 +118,12 @@ def add_commit() -> Response:
 @app.route("/test/rate-limit", methods=["POST"])
 def rate_limit() -> Response:
     """Make the next N commit requests fail the way an exceeded rate limit does."""
-    global _reject_requests, _reject_retry_after
+    global _reject_requests, _reject_retry_after, _reject_secondary
     body: Dict[str, Any] = request.get_json(force=True) or {}
     with _lock:
         _reject_requests = int(body.get("requests", 1))
         _reject_retry_after = int(body.get("retry_after", 1))
+        _reject_secondary = bool(body.get("secondary", False))
     return jsonify({"ok": True})
 
 
@@ -137,13 +147,14 @@ def reset_stats() -> Response:
 
 @app.route("/test/reset", methods=["POST"])
 def reset() -> Response:
-    global _commits, _version, _total_requests, _conditional_hits, _reject_requests
+    global _commits, _version, _total_requests, _conditional_hits, _reject_requests, _reject_secondary
     with _lock:
         _commits = _baseline()
         _version += 1
         _total_requests = 0
         _conditional_hits = 0
         _reject_requests = 0
+        _reject_secondary = False
     return jsonify({"ok": True})
 
 

--- a/acceptance/github_mock/server.py
+++ b/acceptance/github_mock/server.py
@@ -4,6 +4,10 @@ Serves the single endpoint GitHubService polls — `GET /repos/<owner>/<repo>/co
 — returning whatever commit list behave has configured, newest-first (GitHub's
 ordering). Test-only endpoints let behave push new commits so the bot's
 notification flow can be driven without touching the real GitHub API.
+
+Mirrors the parts of GitHub's rate-limit contract the bot depends on: every commits
+response carries an ETag, a matching `If-None-Match` gets a bodyless 304, and behave
+can force rejections that carry `retry-after` so the poller's backoff is exercised.
 """
 import logging
 import threading
@@ -29,11 +33,56 @@ def _baseline() -> List[Dict[str, Any]]:
 # Newest-first list of commits, mirroring GitHub's response ordering.
 _commits: List[Dict[str, Any]] = _baseline()
 
+# Bumped on every change to _commits so the ETag changes with the content. Never
+# reset: a scenario must not be able to hand the bot an ETag it already holds from
+# an earlier scenario, which would 304 against commits it never saw.
+_version: int = 0
+
+# Request counters, so tests can assert conditional requests are actually happening.
+_total_requests: int = 0
+_conditional_hits: int = 0
+
+# When set, the next _reject_requests commit requests answer with a rate-limit
+# rejection carrying this retry-after (seconds).
+_reject_requests: int = 0
+_reject_retry_after: int = 1
+
+
+def _etag() -> str:
+    return f'W/"commits-{_version}"'
+
 
 @app.route("/repos/<owner>/<repo>/commits", methods=["GET"])
 def commits(owner: str, repo: str) -> Response:
+    global _total_requests, _conditional_hits, _reject_requests
     with _lock:
-        return jsonify(list(_commits))
+        _total_requests += 1
+
+        if _reject_requests > 0:
+            _reject_requests -= 1
+            # Shape of a real primary rate-limit rejection: exhausted counter plus a
+            # retry-after telling the client when to come back.
+            return Response(
+                response='{"message": "API rate limit exceeded"}',
+                status=403,
+                content_type="application/json",
+                headers={
+                    "Retry-After": str(_reject_retry_after),
+                    "X-RateLimit-Limit": "60",
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Used": "60",
+                },
+            )
+
+        etag: str = _etag()
+        if request.headers.get("If-None-Match") == etag:
+            _conditional_hits += 1
+            # 304 carries no body, and GitHub does not charge it against the quota.
+            return Response(status=304, headers={"ETag": etag})
+
+        response: Response = jsonify(list(_commits))
+        response.headers["ETag"] = etag
+        return response
 
 
 # ---------------------------------------------------------------------------
@@ -43,6 +92,7 @@ def commits(owner: str, repo: str) -> Response:
 @app.route("/test/add-commit", methods=["POST"])
 def add_commit() -> Response:
     """Prepend a newer commit, as a real push would surface it."""
+    global _version
     body: Dict[str, Any] = request.get_json(force=True) or {}
     sha: str = str(body["sha"])
     commit: Dict[str, Any] = {
@@ -52,14 +102,48 @@ def add_commit() -> Response:
     }
     with _lock:
         _commits.insert(0, commit)
+        _version += 1
+    return jsonify({"ok": True})
+
+
+@app.route("/test/rate-limit", methods=["POST"])
+def rate_limit() -> Response:
+    """Make the next N commit requests fail the way an exceeded rate limit does."""
+    global _reject_requests, _reject_retry_after
+    body: Dict[str, Any] = request.get_json(force=True) or {}
+    with _lock:
+        _reject_requests = int(body.get("requests", 1))
+        _reject_retry_after = int(body.get("retry_after", 1))
+    return jsonify({"ok": True})
+
+
+@app.route("/test/stats", methods=["GET"])
+def stats() -> Response:
+    with _lock:
+        return jsonify({
+            "total_requests": _total_requests,
+            "conditional_hits": _conditional_hits,
+        })
+
+
+@app.route("/test/reset-stats", methods=["POST"])
+def reset_stats() -> Response:
+    global _total_requests, _conditional_hits
+    with _lock:
+        _total_requests = 0
+        _conditional_hits = 0
     return jsonify({"ok": True})
 
 
 @app.route("/test/reset", methods=["POST"])
 def reset() -> Response:
-    global _commits
+    global _commits, _version, _total_requests, _conditional_hits, _reject_requests
     with _lock:
         _commits = _baseline()
+        _version += 1
+        _total_requests = 0
+        _conditional_hits = 0
+        _reject_requests = 0
     return jsonify({"ok": True})
 
 

--- a/dao/Database.ts
+++ b/dao/Database.ts
@@ -79,33 +79,51 @@ const migrateDropCurrentMatch = async (conn: PoolConnection): Promise<void> => {
     }
 };
 
+const tableExists = async (conn: PoolConnection, table: string): Promise<boolean> => {
+    const [rows] = await conn.query<RowDataPacket[]>(
+        'SELECT COUNT(*) AS tbl FROM information_schema.TABLES ' +
+        ' WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :table',
+        { table }
+    );
+    return Number(rows[0]?.tbl) > 0;
+};
+
+const columnExists = async (conn: PoolConnection, table: string, column: string): Promise<boolean> => {
+    const [rows] = await conn.query<RowDataPacket[]>(
+        'SELECT COUNT(*) AS col FROM information_schema.COLUMNS ' +
+        ' WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :table AND COLUMN_NAME = :column',
+        { table, column }
+    );
+    return Number(rows[0]?.col) > 0;
+};
+
 // One-off, idempotent migration: add the columns that back grouped end-of-game announcements
 // (game_history.player_name and .message_id) to databases created before they existed. CREATE
 // TABLE IF NOT EXISTS won't alter an existing table, so add each column when it's missing.
 // Portable across MariaDB/MySQL (no ADD COLUMN IF NOT EXISTS).
 const migrateGameHistoryAnnouncementColumns = async (conn: PoolConnection): Promise<void> => {
-    const columnExists = async (column: string): Promise<boolean> => {
-        const [rows] = await conn.query<RowDataPacket[]>(
-            'SELECT COUNT(*) AS col FROM information_schema.COLUMNS ' +
-            ' WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :table AND COLUMN_NAME = :column',
-            { table: 'game_history', column }
-        );
-        return Number(rows[0]?.col) > 0;
-    };
-    const [tblRows] = await conn.query<RowDataPacket[]>(
-        'SELECT COUNT(*) AS tbl FROM information_schema.TABLES ' +
-        " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'game_history'"
-    );
-    if (Number(tblRows[0]?.tbl) === 0) {
+    if (!(await tableExists(conn, 'game_history'))) {
         return;
     }
-    if (!(await columnExists('player_name'))) {
+    if (!(await columnExists(conn, 'game_history', 'player_name'))) {
         console.log('Adding game_history.player_name for grouped end-of-game announcements.');
         await conn.query('ALTER TABLE game_history ADD COLUMN player_name VARCHAR(255) NULL');
     }
-    if (!(await columnExists('message_id'))) {
+    if (!(await columnExists(conn, 'game_history', 'message_id'))) {
         console.log('Adding game_history.message_id for grouped end-of-game announcements.');
         await conn.query('ALTER TABLE game_history ADD COLUMN message_id BIGINT NULL');
+    }
+};
+
+// One-off, idempotent migration: github_state.etag backs conditional polling (If-None-Match),
+// so databases created before it existed need the column added in place.
+const migrateGithubStateEtagColumn = async (conn: PoolConnection): Promise<void> => {
+    if (!(await tableExists(conn, 'github_state'))) {
+        return;
+    }
+    if (!(await columnExists(conn, 'github_state', 'etag'))) {
+        console.log('Adding github_state.etag for conditional GitHub API requests.');
+        await conn.query('ALTER TABLE github_state ADD COLUMN etag VARCHAR(255) NULL');
     }
 };
 
@@ -117,6 +135,7 @@ export const ensureSchema = async (): Promise<void> => {
     try {
         await migrateDropCurrentMatch(conn);
         await migrateGameHistoryAnnouncementColumns(conn);
+        await migrateGithubStateEtagColumn(conn);
         for (const statement of splitStatements(ddl)) {
             await conn.query(statement);
         }

--- a/dao/GithubDAO.ts
+++ b/dao/GithubDAO.ts
@@ -26,6 +26,20 @@ class GithubDAO {
             { sha }
         ).then(() => undefined);
     }
+
+    // The ETag of the last commits response, replayed as If-None-Match so unchanged
+    // polls come back 304 — free against GitHub's primary rate limit.
+    async getGithubEtag(): Promise<string | undefined> {
+        const rows = await query<RowDataPacket[]>('SELECT etag FROM github_state WHERE id = 1');
+        return rows[0]?.etag ?? undefined;
+    }
+
+    setGithubEtag(etag: string): Promise<void> {
+        return query<ResultSetHeader>(
+            'INSERT INTO github_state (id, etag) VALUES (1, :etag) ON DUPLICATE KEY UPDATE etag = VALUES(etag)',
+            { etag }
+        ).then(() => undefined);
+    }
 }
 
 export default GithubDAO;

--- a/dao/schema.sql
+++ b/dao/schema.sql
@@ -101,8 +101,10 @@ CREATE TABLE IF NOT EXISTS rollcall_schedule (
 
 -- Single-row state for the one polled GitHub repo.
 CREATE TABLE IF NOT EXISTS github_state (
-    id       TINYINT     NOT NULL DEFAULT 1,
-    last_sha VARCHAR(64) NULL,
+    id       TINYINT      NOT NULL DEFAULT 1,
+    last_sha VARCHAR(64)  NULL,
+    -- ETag of the last commits response, replayed as If-None-Match on the next poll.
+    etag     VARCHAR(255) NULL,
     PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/githubRateLimit.ts
+++ b/githubRateLimit.ts
@@ -38,20 +38,38 @@ const numericHeader = (headers: HeaderBag, name: string): number | null => {
  * as opposed to any other 403 (missing token, private repo, blocked user agent).
  *
  * Primary limits zero out the remaining counter; secondary limits answer with a
- * retry-after instead. Both arrive as 403 or 429.
+ * retry-after — or, per GitHub's docs, with neither header and only a message body
+ * saying so. Both kinds arrive as 403 or 429.
  */
-export const isRateLimitRejection = (status: number, headers: HeaderBag): boolean => {
-    if (status !== 403 && status !== 429) {
+export const isRateLimitRejection = (status: number, headers: HeaderBag, body?: string): boolean => {
+    // 429 has no other meaning in GitHub's API: it is always "too many requests".
+    if (status === 429) {
+        return true;
+    }
+    if (status !== 403) {
         return false;
     }
-    return headers.get('retry-after') !== null || headers.get('x-ratelimit-remaining') === '0';
+    if (headers.get('retry-after') !== null || headers.get('x-ratelimit-remaining') === '0') {
+        return true;
+    }
+    // A bare 403 is rate limiting only when it says so. Other 403s (bad credentials,
+    // private repo) must keep failing loudly rather than putting the poller to sleep.
+    return body !== undefined && /\brate limit\b/i.test(body);
 };
 
 /**
  * How long to hold off before the next request, honouring retry-after first (GitHub
- * documents it as authoritative) and falling back to the reset timestamp.
+ * documents it as authoritative), then the reset timestamp.
+ *
+ * `consecutiveRateLimits` only matters when a rejection carries neither header: GitHub
+ * asks for at least a minute in that case, growing while the failures continue, and
+ * warns that hammering a limit risks the integration being banned.
  */
-export const rateLimitBackoffMs = (headers: HeaderBag, now: number): number => {
+export const rateLimitBackoffMs = (
+    headers: HeaderBag,
+    now: number,
+    consecutiveRateLimits: number = 1
+): number => {
     const clamp = (ms: number): number => Math.min(Math.max(ms, 0), MAX_BACKOFF_MS);
 
     const retryAfter = numericHeader(headers, 'retry-after');
@@ -69,7 +87,8 @@ export const rateLimitBackoffMs = (headers: HeaderBag, now: number): number => {
         }
     }
 
-    return FALLBACK_BACKOFF_MS;
+    // 2 ** large is Infinity, which clamp folds back to the cap.
+    return clamp(FALLBACK_BACKOFF_MS * 2 ** Math.max(0, consecutiveRateLimits - 1));
 };
 
 /**

--- a/githubRateLimit.ts
+++ b/githubRateLimit.ts
@@ -1,0 +1,93 @@
+/**
+ * Helpers for reading GitHub's rate-limit signalling off a response.
+ *
+ * Kept separate from GitHubService so the header arithmetic — the part that is easy
+ * to get subtly wrong — can be unit tested without a bot, a database or a network.
+ *
+ * See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+ */
+
+// Just enough of the Headers interface to cover what we read, so tests can pass a
+// plain object instead of constructing a whole Response.
+export interface HeaderBag {
+    get(name: string): string | null;
+}
+
+// GitHub's primary rate-limit window is hourly, so never pause longer than that even
+// if a bogus reset timestamp claims we should.
+const MAX_BACKOFF_MS = 60 * 60 * 1000;
+// Used when GitHub rejects us without saying when to come back.
+const FALLBACK_BACKOFF_MS = 60 * 1000;
+
+// Warn once the hourly budget is nearly spent, so an impending 403 shows up in the
+// logs before polls actually start failing.
+export const LOW_QUOTA_THRESHOLD = 10;
+
+const numericHeader = (headers: HeaderBag, name: string): number | null => {
+    const raw = headers.get(name);
+    // Number('') is 0, so an empty header would otherwise read as a real value.
+    if (raw === null || raw.trim() === '') {
+        return null;
+    }
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : null;
+};
+
+/**
+ * Whether a failed response is GitHub turning us away for exceeding a rate limit,
+ * as opposed to any other 403 (missing token, private repo, blocked user agent).
+ *
+ * Primary limits zero out the remaining counter; secondary limits answer with a
+ * retry-after instead. Both arrive as 403 or 429.
+ */
+export const isRateLimitRejection = (status: number, headers: HeaderBag): boolean => {
+    if (status !== 403 && status !== 429) {
+        return false;
+    }
+    return headers.get('retry-after') !== null || headers.get('x-ratelimit-remaining') === '0';
+};
+
+/**
+ * How long to hold off before the next request, honouring retry-after first (GitHub
+ * documents it as authoritative) and falling back to the reset timestamp.
+ */
+export const rateLimitBackoffMs = (headers: HeaderBag, now: number): number => {
+    const clamp = (ms: number): number => Math.min(Math.max(ms, 0), MAX_BACKOFF_MS);
+
+    const retryAfter = numericHeader(headers, 'retry-after');
+    if (retryAfter !== null && retryAfter > 0) {
+        return clamp(retryAfter * 1000);
+    }
+
+    const reset = numericHeader(headers, 'x-ratelimit-reset');
+    if (reset !== null && reset > 0) {
+        const untilReset = reset * 1000 - now;
+        // A reset in the past means the window already rolled over; fall through to
+        // the fallback rather than retrying instantly against a limit we just hit.
+        if (untilReset > 0) {
+            return clamp(untilReset);
+        }
+    }
+
+    return FALLBACK_BACKOFF_MS;
+};
+
+/**
+ * A log line when the remaining quota is low enough to be worth flagging, or null
+ * when there is nothing to say. Also returns null when the headers are absent, which
+ * is the case for mocks and non-GitHub proxies.
+ */
+export const lowQuotaWarning = (headers: HeaderBag): string | null => {
+    const remaining = numericHeader(headers, 'x-ratelimit-remaining');
+    if (remaining === null || remaining > LOW_QUOTA_THRESHOLD) {
+        return null;
+    }
+
+    const limit = headers.get('x-ratelimit-limit') ?? '?';
+    const reset = numericHeader(headers, 'x-ratelimit-reset');
+    const resetText = reset !== null && reset > 0
+        ? `, resets at ${new Date(reset * 1000).toISOString()}`
+        : '';
+
+    return `GitHub API quota nearly exhausted: ${remaining}/${limit} requests remaining${resetText}.`;
+};

--- a/test/githubRateLimit.test.ts
+++ b/test/githubRateLimit.test.ts
@@ -19,14 +19,22 @@ test('a 403 with an exhausted quota is a rate-limit rejection', () => {
     assert.equal(isRateLimitRejection(403, headers({ 'x-ratelimit-remaining': '0' })), true);
 });
 
-test('a 429 with retry-after is a rate-limit rejection', () => {
+test('a 429 is always a rate-limit rejection, headers or not', () => {
+    // GitHub uses 429 for nothing else, and secondary limits may omit both headers.
     assert.equal(isRateLimitRejection(429, headers({ 'retry-after': '60' })), true);
+    assert.equal(isRateLimitRejection(429, headers({})), true);
+});
+
+test('a headerless secondary limit is recognised from the response body', () => {
+    const body = '{"message": "You have exceeded a secondary rate limit. Please wait a few minutes."}';
+    assert.equal(isRateLimitRejection(403, headers({}), body), true);
 });
 
 test('a 403 with quota to spare is some other refusal, not a rate limit', () => {
     // e.g. a private repo or a bad token: backing off for an hour would be wrong.
     assert.equal(isRateLimitRejection(403, headers({ 'x-ratelimit-remaining': '4999' })), false);
     assert.equal(isRateLimitRejection(403, headers({})), false);
+    assert.equal(isRateLimitRejection(403, headers({}), '{"message": "Bad credentials"}'), false);
 });
 
 test('non-403/429 failures are never rate limits', () => {
@@ -64,6 +72,19 @@ test('unparseable or missing headers fall back to a fixed backoff', () => {
     assert.equal(rateLimitBackoffMs(headers({ 'retry-after': 'soon' }), NOW), 60_000);
     assert.equal(rateLimitBackoffMs(headers({ 'retry-after': '' }), NOW), 60_000);
     assert.equal(rateLimitBackoffMs(headers({ 'retry-after': '0' }), NOW), 60_000);
+});
+
+test('a headerless rejection backs off exponentially while it keeps failing', () => {
+    // GitHub's documented handling for secondary limits that say nothing about timing.
+    assert.equal(rateLimitBackoffMs(headers({}), NOW, 1), 60_000);
+    assert.equal(rateLimitBackoffMs(headers({}), NOW, 2), 120_000);
+    assert.equal(rateLimitBackoffMs(headers({}), NOW, 3), 240_000);
+    // ...and still stops at the window length rather than growing without bound.
+    assert.equal(rateLimitBackoffMs(headers({}), NOW, 99), 60 * 60 * 1000);
+});
+
+test('escalation never overrides a time GitHub actually gave us', () => {
+    assert.equal(rateLimitBackoffMs(headers({ 'retry-after': '30' }), NOW, 5), 30_000);
 });
 
 test('a healthy quota produces no warning', () => {

--- a/test/githubRateLimit.test.ts
+++ b/test/githubRateLimit.test.ts
@@ -1,0 +1,87 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    HeaderBag,
+    isRateLimitRejection,
+    lowQuotaWarning,
+    rateLimitBackoffMs
+} from '../githubRateLimit.js';
+
+// Header names are matched case-insensitively by fetch's Headers, and lowercase
+// everywhere in the module, so a plain lookup is a faithful stand-in.
+const headers = (values: Record<string, string>): HeaderBag => ({
+    get: (name: string): string | null => values[name.toLowerCase()] ?? null
+});
+
+const NOW = 1_700_000_000_000; // Fixed clock so backoff maths is deterministic.
+
+test('a 403 with an exhausted quota is a rate-limit rejection', () => {
+    assert.equal(isRateLimitRejection(403, headers({ 'x-ratelimit-remaining': '0' })), true);
+});
+
+test('a 429 with retry-after is a rate-limit rejection', () => {
+    assert.equal(isRateLimitRejection(429, headers({ 'retry-after': '60' })), true);
+});
+
+test('a 403 with quota to spare is some other refusal, not a rate limit', () => {
+    // e.g. a private repo or a bad token: backing off for an hour would be wrong.
+    assert.equal(isRateLimitRejection(403, headers({ 'x-ratelimit-remaining': '4999' })), false);
+    assert.equal(isRateLimitRejection(403, headers({})), false);
+});
+
+test('non-403/429 failures are never rate limits', () => {
+    assert.equal(isRateLimitRejection(404, headers({ 'x-ratelimit-remaining': '0' })), false);
+    assert.equal(isRateLimitRejection(500, headers({ 'retry-after': '30' })), false);
+});
+
+test('retry-after wins over the reset timestamp', () => {
+    const backoff = rateLimitBackoffMs(headers({
+        'retry-after': '45',
+        'x-ratelimit-reset': String((NOW + 3000_000) / 1000)
+    }), NOW);
+    assert.equal(backoff, 45_000);
+});
+
+test('the reset timestamp is used when retry-after is absent', () => {
+    const resetAt = NOW + 120_000;
+    const backoff = rateLimitBackoffMs(headers({ 'x-ratelimit-reset': String(resetAt / 1000) }), NOW);
+    assert.equal(backoff, 120_000);
+});
+
+test('a reset already in the past falls back rather than retrying instantly', () => {
+    const backoff = rateLimitBackoffMs(headers({ 'x-ratelimit-reset': String((NOW - 60_000) / 1000) }), NOW);
+    assert.equal(backoff, 60_000);
+});
+
+test('backoff is capped at the length of the rate-limit window', () => {
+    // A bogus reset a year out must not stall the poller until next year.
+    const backoff = rateLimitBackoffMs(headers({ 'x-ratelimit-reset': String((NOW / 1000) + 31_536_000) }), NOW);
+    assert.equal(backoff, 60 * 60 * 1000);
+});
+
+test('unparseable or missing headers fall back to a fixed backoff', () => {
+    assert.equal(rateLimitBackoffMs(headers({}), NOW), 60_000);
+    assert.equal(rateLimitBackoffMs(headers({ 'retry-after': 'soon' }), NOW), 60_000);
+    assert.equal(rateLimitBackoffMs(headers({ 'retry-after': '' }), NOW), 60_000);
+    assert.equal(rateLimitBackoffMs(headers({ 'retry-after': '0' }), NOW), 60_000);
+});
+
+test('a healthy quota produces no warning', () => {
+    assert.equal(lowQuotaWarning(headers({ 'x-ratelimit-remaining': '4999', 'x-ratelimit-limit': '5000' })), null);
+});
+
+test('a nearly exhausted quota warns with the remaining count and reset time', () => {
+    const warning = lowQuotaWarning(headers({
+        'x-ratelimit-remaining': '3',
+        'x-ratelimit-limit': '60',
+        'x-ratelimit-reset': String(NOW / 1000)
+    }));
+    assert.match(warning ?? '', /3\/60/);
+    assert.match(warning ?? '', /2023-11-14T22:13:20\.000Z/);
+});
+
+test('absent quota headers produce no warning', () => {
+    // Mocks and proxies don't send them; an empty header must not read as zero.
+    assert.equal(lowQuotaWarning(headers({})), null);
+    assert.equal(lowQuotaWarning(headers({ 'x-ratelimit-remaining': '' })), null);
+});


### PR DESCRIPTION
The commit poller spent a full request on every tick and, once GitHub
started refusing it, kept requesting on schedule — rejected requests still
count as used, so the bucket stayed pinned and the only sign was a console
line. Unauthenticated callers get 60 requests per hour per source IP, shared
with anything else on the same address.

Send If-None-Match with the previous response's ETag: an unchanged repo
answers 304, which GitHub does not charge against the primary rate limit.
The ETag is persisted alongside last_sha so a restart resumes conditional
polling instead of spending a request to relearn it, and it is only stored
once the response it belongs to has been fully announced — saving it earlier
would leave the poller 304ing against commits it never sent.

On a 403/429 that carries retry-after or an exhausted counter, pause polling
until the window reopens rather than retrying into the wall. Other 403s (bad
token, private repo) keep their existing handling. Backoff is capped at the
length of the rate-limit window so a bogus reset timestamp cannot stall the
poller indefinitely, and a nearly exhausted quota is logged before requests
start failing.

Setting GITHUB_TOKEN remains the other half of this: it raises the ceiling
from 60 to 5,000 per hour and is what makes 304 responses free.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WvuS4HYsNRNSBEXmAD16Zv